### PR TITLE
Add adapter definition for node-based children filtering

### DIFF
--- a/python/src/treeviz/definitions/yaml_utils.py
+++ b/python/src/treeviz/definitions/yaml_utils.py
@@ -109,9 +109,19 @@ def serialize_dict_to_yaml(
 
     for field_name, doc in field_docs.items():
         if field_name in commented_data:
-            commented_data.yaml_set_comment_before_after_key(
-                field_name, before=doc
-            )
+            # Special handling for children field to show examples
+            if field_name == "children":
+                extended_doc = (
+                    doc
+                    + "\n# Examples:\n# children: children  # traditional attribute\n# children:\n#   include: ['paragraph', 'section', 'h*']\n#   exclude: ['footer']"
+                )
+                commented_data.yaml_set_comment_before_after_key(
+                    field_name, before=extended_doc
+                )
+            else:
+                commented_data.yaml_set_comment_before_after_key(
+                    field_name, before=doc
+                )
 
     stream = StringIO()
     yml.dump(commented_data, stream)

--- a/python/tests/test_children_selector.py
+++ b/python/tests/test_children_selector.py
@@ -1,0 +1,198 @@
+"""
+Test children selector functionality for node-based filtering.
+
+This module tests the new ChildrenSelector dataclass and its integration
+with the adapter system.
+"""
+
+from dataclasses import asdict
+
+from treeviz.definitions.model import Definition, ChildrenSelector
+from treeviz.adapters import adapt_node
+
+
+class TestChildrenSelector:
+    """Test ChildrenSelector pattern matching functionality."""
+
+    def test_children_selector_basic_patterns(self):
+        """Test basic include/exclude patterns."""
+        selector = ChildrenSelector(
+            include=["paragraph", "section"], exclude=["footer"]
+        )
+
+        assert selector.matches("paragraph") is True
+        assert selector.matches("section") is True
+        assert selector.matches("footer") is False
+        assert selector.matches("header") is False
+
+    def test_children_selector_wildcard_patterns(self):
+        """Test wildcard patterns with * character."""
+        selector = ChildrenSelector(
+            include=["h*", "section"], exclude=["hidden*"]
+        )
+
+        assert selector.matches("h1") is True
+        assert selector.matches("h2") is True
+        assert selector.matches("heading") is True
+        assert selector.matches("section") is True
+        assert selector.matches("hidden_element") is False
+        assert selector.matches("hidden") is False
+        assert selector.matches("paragraph") is False
+
+    def test_children_selector_star_include_with_exclude(self):
+        """Test star include pattern with specific excludes."""
+        selector = ChildrenSelector(include=["*"], exclude=["footer", "script"])
+
+        assert selector.matches("paragraph") is True
+        assert selector.matches("section") is True
+        assert selector.matches("div") is True
+        assert selector.matches("footer") is False
+        assert selector.matches("script") is False
+
+    def test_children_selector_empty_or_none_type(self):
+        """Test handling of empty or None node types."""
+        selector = ChildrenSelector(include=["*"], exclude=[])
+
+        assert selector.matches("") is False
+        assert selector.matches(None) is False
+
+    def test_definition_from_dict_with_children_selector(self):
+        """Test Definition.from_dict properly converts children dict to ChildrenSelector."""
+        def_dict = {
+            "label": "text",
+            "type": "node_type",
+            "children": {
+                "include": ["paragraph", "section", "h*"],
+                "exclude": ["footer"],
+            },
+        }
+
+        definition = Definition.from_dict(def_dict)
+
+        assert isinstance(definition.children, ChildrenSelector)
+        assert definition.children.include == ["paragraph", "section", "h*"]
+        assert definition.children.exclude == ["footer"]
+
+    def test_definition_from_dict_with_string_children(self):
+        """Test Definition.from_dict preserves string children attribute."""
+        def_dict = {
+            "label": "text",
+            "type": "node_type",
+            "children": "child_nodes",
+        }
+
+        definition = Definition.from_dict(def_dict)
+
+        assert isinstance(definition.children, str)
+        assert definition.children == "child_nodes"
+
+    def test_definition_serialization_with_children_selector(self):
+        """Test that ChildrenSelector properly serializes to dict."""
+        def_dict = {
+            "children": {
+                "include": ["paragraph", "section"],
+                "exclude": ["footer"],
+            }
+        }
+
+        definition = Definition.from_dict(def_dict)
+        serialized = asdict(definition)
+
+        assert serialized["children"]["include"] == ["paragraph", "section"]
+        assert serialized["children"]["exclude"] == ["footer"]
+
+
+class MockNode:
+    """Mock node for testing adapter functionality."""
+
+    def __init__(self, node_type, **kwargs):
+        self.node_type = node_type
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class TestChildrenSelectorIntegration:
+    """Test integration of ChildrenSelector with adapter system."""
+
+    def test_adapt_node_with_children_selector_filtering(self):
+        """Test that adapt_node properly filters children using ChildrenSelector."""
+        # Create a mock source node with various child types
+        source_node = MockNode(
+            "session",
+            # Add various attributes that might contain child nodes
+            elements=[
+                MockNode("paragraph", text="First paragraph"),
+                MockNode("footer", text="Footer content"),
+                MockNode("section", text="Section content"),
+                MockNode("script", text="Script content"),
+            ],
+            metadata={"title": "Test Session"},
+        )
+
+        # Define adapter with ChildrenSelector
+        def_dict = {
+            "label": "text",
+            "type": "node_type",
+            "children": {
+                "include": ["paragraph", "section"],
+                "exclude": ["footer", "script"],
+            },
+        }
+
+        result = adapt_node(source_node, def_dict)
+
+        # Should have filtered to only paragraph and section children
+        assert len(result.children) == 2
+        child_types = [child.type for child in result.children]
+        assert "paragraph" in child_types
+        assert "section" in child_types
+        assert "footer" not in child_types
+        assert "script" not in child_types
+
+    def test_adapt_node_with_children_selector_wildcard(self):
+        """Test ChildrenSelector with wildcard patterns."""
+        source_node = MockNode(
+            "document",
+            content=[
+                MockNode("h1", text="Main heading"),
+                MockNode("h2", text="Sub heading"),
+                MockNode("paragraph", text="Content"),
+                MockNode("footer", text="Footer"),
+            ],
+        )
+
+        def_dict = {
+            "label": "text",
+            "type": "node_type",
+            "children": {"include": ["h*", "paragraph"], "exclude": ["footer"]},
+        }
+
+        result = adapt_node(source_node, def_dict)
+
+        assert len(result.children) == 3
+        child_types = [child.type for child in result.children]
+        assert "h1" in child_types
+        assert "h2" in child_types
+        assert "paragraph" in child_types
+        assert "footer" not in child_types
+
+    def test_adapt_node_fallback_to_traditional_children(self):
+        """Test that string children attribute still works as before."""
+        source_node = MockNode(
+            "root",
+            children=[
+                MockNode("paragraph", text="First"),
+                MockNode("paragraph", text="Second"),
+            ],
+        )
+
+        def_dict = {
+            "label": "text",
+            "type": "node_type",
+            "children": "children",  # Traditional string attribute
+        }
+
+        result = adapt_node(source_node, def_dict)
+
+        assert len(result.children) == 2
+        assert all(child.type == "paragraph" for child in result.children)


### PR DESCRIPTION
## Summary
- Implements ChildrenSelector with include/exclude patterns for node-based children filtering
- Supports wildcard patterns with `*` character
- Maintains full backward compatibility with existing string children attributes
- Adds comprehensive test coverage for new functionality

## Implementation Details
- Added `ChildrenSelector` dataclass with pattern matching functionality using `fnmatch`
- Updated `Definition.children` field to accept `Union[str, ChildrenSelector]`
- Enhanced adapter logic to handle both traditional attribute-based and new node-based children extraction
- Updated `get-definition` output to show usage examples for both approaches

## Example Usage
```yaml
children:
  include: ['paragraph', 'section', 'h*']
  exclude: ['footer']
```

This allows adapting tree structures where children are nodes themselves rather than stored in specific attributes, making it easier to work with XML-like data structures.

## Test Plan
- [x] Pattern matching with basic include/exclude lists
- [x] Wildcard pattern support with `*` character  
- [x] Integration with existing adapter system
- [x] Backward compatibility with string children attributes
- [x] Proper serialization/deserialization of ChildrenSelector
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)