### PR TITLE
Refactor: Node.metadata → Node.extra for clearer semantics

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 3viz, a terminal ast vizualizer for document based ASTs.
 
 3viz is designed to simplify reasing about document tree. The 1-line per node and colunar layout makes
-scanning and grokking structure easy, while the texttual represntations, icons and metadata give 
+scanning and grokking structure easy, while the texttual represntations, icons and extra give 
 additional informattion at a glance.
 
 Being line based, it makes diffing trees useful and can be invaluable in debugging these parse trees.
@@ -47,7 +47,7 @@ Or as a library.
       icon: Optional[str] = None  # Unicode character icon
       content_lines: int = 1  # Number of lines this node represents
       source_location: Optional[Dict[str, Any]] = 
-      metadata: Dict[str, Any] :  node metatdata / attributes for display
+      extra: Dict[str, Any] :  node metatdata / attributes for display
       children: List["Node"] 
 
       Which can be passed both as objects/dicts in the library or in a json file for the cli.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1388,7 +1388,7 @@ sphinx = "*"
 [[package]]
 name = "pkginfo"
 version = "1.12.1.2"
-description = "Query extra from sdists / bdists / installed packages."
+description = "Query metadata from sdists / bdists / installed packages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
@@ -1942,12 +1942,12 @@ files = [
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.5.2) ; sys_platform != \"cygwin\""]
-core = ["importlib-extra (>=6) ; python_version < \"3.10\"", "importlib-resources (>=5.10.2) ; python_version < \"3.9\"", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+core = ["importlib-metadata (>=6) ; python_version < \"3.10\"", "importlib-resources (>=5.10.2) ; python_version < \"3.9\"", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-extra (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.12.*)", "pytest-mypy"]
+type = ["importlib-metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.12.*)", "pytest-mypy"]
 
 [[package]]
 name = "shellingham"
@@ -2439,7 +2439,7 @@ files = [
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
-[extra]
+[metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
 content-hash = "d3a7cf520eebe516098e5fa15be8dcb23bb5d045bf126a647a42def0d3298f18"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1388,7 +1388,7 @@ sphinx = "*"
 [[package]]
 name = "pkginfo"
 version = "1.12.1.2"
-description = "Query metadata from sdists / bdists / installed packages."
+description = "Query extra from sdists / bdists / installed packages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
@@ -1942,12 +1942,12 @@ files = [
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.5.2) ; sys_platform != \"cygwin\""]
-core = ["importlib-metadata (>=6) ; python_version < \"3.10\"", "importlib-resources (>=5.10.2) ; python_version < \"3.9\"", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+core = ["importlib-extra (>=6) ; python_version < \"3.10\"", "importlib-resources (>=5.10.2) ; python_version < \"3.9\"", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.12.*)", "pytest-mypy"]
+type = ["importlib-extra (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.12.*)", "pytest-mypy"]
 
 [[package]]
 name = "shellingham"
@@ -2439,7 +2439,7 @@ files = [
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
-[metadata]
+[extra]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
 content-hash = "d3a7cf520eebe516098e5fa15be8dcb23bb5d045bf126a647a42def0d3298f18"

--- a/python/src/treeviz/__init__.py
+++ b/python/src/treeviz/__init__.py
@@ -65,7 +65,7 @@ Node Structure:
     - icon: Explicit Unicode symbol (optional) 
     - content_lines: Number of lines represented (default: 1)
     - source_location: Line/column info from original source (optional)
-    - metadata: Extensible key-value data (optional)
+    - extra: Extensible key-value data (optional)
     - children: Child nodes (optional)
 
 Declarative Configuration:
@@ -85,7 +85,7 @@ Advanced Features (Phase 2)
 Complex Path Expressions:
     
     # Dot notation for nested access
-    "label": "metadata.title"
+    "label": "extra.title"
     
     # Array indexing 
     "label": "children[0].name"
@@ -99,7 +99,7 @@ Conditional Extraction:
     "type_overrides": {
         "function": {
             "label": "name",
-            "metadata": {"params": "parameters", "returns": "return_type"}
+            "extra": {"params": "parameters", "returns": "return_type"}
         },
         "class": {
             "label": {"path": "class_name", "transform": "capitalize"}

--- a/python/src/treeviz/adapters/core.py
+++ b/python/src/treeviz/adapters/core.py
@@ -5,7 +5,6 @@ This module provides the main node adaptation functionality, converting
 source AST nodes to 3viz Node format using declarative definitions.
 """
 
-import sys
 from typing import Any, Dict, Optional
 
 from ..model import Node
@@ -42,7 +41,7 @@ def adapt_node(source_node: Any, def_: Dict[str, Any]) -> Optional[Node]:
     effective_icon = definition.icon
     effective_content_lines = definition.content_lines
     effective_source_location = definition.source_location
-    effective_metadata = definition.metadata
+    effective_extra = definition.extra
 
     # Apply type-specific overrides if they exist
     if node_type and node_type in definition.type_overrides:
@@ -57,7 +56,7 @@ def adapt_node(source_node: Any, def_: Dict[str, Any]) -> Optional[Node]:
         effective_source_location = overrides.get(
             "source_location", effective_source_location
         )
-        effective_metadata = overrides.get("metadata", effective_metadata)
+        effective_extra = overrides.get("extra", effective_extra)
 
     # Extract basic attributes using advanced extractor
     label = extract_attribute(source_node, effective_label)
@@ -72,9 +71,9 @@ def adapt_node(source_node: Any, def_: Dict[str, Any]) -> Optional[Node]:
 
     source_location = extract_attribute(source_node, effective_source_location)
 
-    # Extract metadata using advanced extractor
-    extracted_metadata = extract_attribute(source_node, effective_metadata)
-    metadata = extracted_metadata if extracted_metadata is not None else {}
+    # Extract extra using advanced extractor
+    extracted_extra = extract_attribute(source_node, effective_extra)
+    extra = extracted_extra if extracted_extra is not None else {}
 
     # Apply icon mapping if no explicit icon
     if not icon and node_type and node_type in definition.icons:
@@ -145,7 +144,7 @@ def adapt_node(source_node: Any, def_: Dict[str, Any]) -> Optional[Node]:
         icon=icon,
         content_lines=content_lines,
         source_location=source_location,
-        metadata=metadata,
+        extra=extra,
         children=children,
     )
 

--- a/python/src/treeviz/definitions/model.py
+++ b/python/src/treeviz/definitions/model.py
@@ -109,10 +109,10 @@ class Definition:
             "doc": "Field name for source location info (line/column numbers)"
         },
     )
-    metadata: Any = field(
+    extra: Any = field(
         default_factory=dict,
         metadata={
-            "doc": "Field name for additional metadata extraction, or dict for static metadata"
+            "doc": "Field name for additional extra extraction, or dict for static extra"
         },
     )
 

--- a/python/src/treeviz/definitions/yaml_utils.py
+++ b/python/src/treeviz/definitions/yaml_utils.py
@@ -2,7 +2,7 @@
 YAML utilities for treeviz definitions.
 
 This module provides utilities for serializing definitions to YAML 
-with comments extracted from dataclass field metadata using ruamel.yaml.
+with comments extracted from dataclass field extra using ruamel.yaml.
 """
 
 from typing import Dict, Any
@@ -19,7 +19,7 @@ except ImportError:
 
 def get_dataclass_field_docs(dataclass_obj: Any) -> Dict[str, str]:
     """
-    Extract field documentation from any dataclass metadata.
+    Extract field documentation from any dataclass extra.
 
     Args:
         dataclass_obj: Any dataclass instance or class

--- a/python/src/treeviz/model.py
+++ b/python/src/treeviz/model.py
@@ -23,7 +23,7 @@ class Node:
     - Visual hierarchy through children
     - Content preview through label
     - Type identification through type and icon
-    - Metadata extensibility
+    - Extra extensibility
     - Source location tracking
     """
 
@@ -34,7 +34,7 @@ class Node:
     source_location: Optional[Dict[str, Any]] = (
         None  # Line/column info from original source
     )
-    metadata: Dict[str, Any] = field(
+    extra: Dict[str, Any] = field(
         default_factory=dict
     )  # Extensible key-value data
     children: List["Node"] = field(default_factory=list)  # Child nodes

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -54,11 +54,11 @@ class NodeAssertion:
         ), f"Expected source_location {expected}, got {self.node.source_location}"
         return self
 
-    def has_metadata(self, expected: Dict) -> "NodeAssertion":
-        """Assert node has expected metadata."""
+    def has_extra(self, expected: Dict) -> "NodeAssertion":
+        """Assert node has expected extra."""
         assert (
-            self.node.metadata == expected
-        ), f"Expected metadata {expected}, got {self.node.metadata}"
+            self.node.extra == expected
+        ), f"Expected extra {expected}, got {self.node.extra}"
         return self
 
     def has_children_count(self, expected: int) -> "NodeAssertion":
@@ -146,7 +146,7 @@ def sample_node():
         icon="⧉",
         content_lines=5,
         source_location={"line": 10, "column": 5},
-        metadata={"key": "value"},
+        extra={"key": "value"},
         children=[child],
     )
 

--- a/python/tests/test_integration_essential.py
+++ b/python/tests/test_integration_essential.py
@@ -100,7 +100,7 @@ class TestEssentialIntegration:
                 {"type": "include_me", "value": "keep"},
                 {"type": "exclude_me", "value": "remove"},
                 {"type": "include_me", "value": "also_keep"},
-                {"type": "meta", "value": "metadata"},
+                {"type": "meta", "value": "extra"},
             ],
         }
 

--- a/python/tests/treeviz/adapters/test__utils.py
+++ b/python/tests/treeviz/adapters/test__utils.py
@@ -110,15 +110,15 @@ class TestExitOnErrorDecorator:
             in stderr_output
         )
 
-    def test_decorator_preserves_function_metadata(self):
-        """Test that decorator preserves original function metadata."""
+    def test_decorator_preserves_function_extra(self):
+        """Test that decorator preserves original function extra."""
 
         @exit_on_error
         def documented_func(x):
             """This function has documentation."""
             return x * 2
 
-        # Note: Basic decorator doesn't preserve metadata,
+        # Note: Basic decorator doesn't preserve extra,
         # but we can test that it's still callable
         assert callable(documented_func)
 

--- a/python/tests/treeviz/definitions/test__yaml_utils.py
+++ b/python/tests/treeviz/definitions/test__yaml_utils.py
@@ -25,21 +25,21 @@ class SampleDataclass:
     children: str = field(
         metadata={"doc": "The children field"}, default="child_nodes"
     )
-    no_doc: str = "no_metadata"
+    no_doc: str = "no_extra"
 
 
 class TestGetDataclassFieldDocs:
     """Test get_dataclass_field_docs function."""
 
-    def test_get_field_docs_with_metadata(self):
-        """Test extracting field documentation from dataclass metadata."""
+    def test_get_field_docs_with_extra(self):
+        """Test extracting field documentation from dataclass extra."""
         instance = SampleDataclass(name="test", count=5)
         docs = get_dataclass_field_docs(instance)
 
         assert docs["name"] == "The name field"
         assert docs["count"] == "The count field"
         assert docs["children"] == "The children field"
-        assert "no_doc" not in docs  # No metadata
+        assert "no_doc" not in docs  # No extra
 
     def test_get_field_docs_from_class(self):
         """Test extracting field documentation from dataclass class."""
@@ -56,14 +56,14 @@ class TestGetDataclassFieldDocs:
 
         assert docs == {}
 
-    def test_get_field_docs_no_metadata(self):
-        """Test dataclass with no field metadata."""
+    def test_get_field_docs_no_extra(self):
+        """Test dataclass with no field extra."""
 
         @dataclass
-        class NoMetadata:
+        class NoExtra:
             value: str
 
-        docs = get_dataclass_field_docs(NoMetadata("test"))
+        docs = get_dataclass_field_docs(NoExtra("test"))
         assert docs == {}
 
 

--- a/python/tests/treeviz/fixtures.py
+++ b/python/tests/treeviz/fixtures.py
@@ -44,7 +44,7 @@ def assert_node_properties(
     icon: Optional[str] = None,
     content_lines: Optional[int] = None,
     source_location: Optional[Dict] = None,
-    metadata: Optional[Dict] = None,
+    extra: Optional[Dict] = None,
     children: Optional[List[Node]] = None,
     children_count: Optional[int] = None,
 ) -> None:
@@ -83,10 +83,8 @@ def assert_node_properties(
             node.source_location == source_location
         ), f"Expected source_location {source_location}, got {node.source_location}"
 
-    if metadata is not None:
-        assert (
-            node.metadata == metadata
-        ), f"Expected metadata {metadata}, got {node.metadata}"
+    if extra is not None:
+        assert node.extra == extra, f"Expected extra {extra}, got {node.extra}"
 
     if children is not None:
         assert (
@@ -130,7 +128,7 @@ def sample_node():
         icon="⧉",
         content_lines=5,
         source_location={"line": 10, "column": 5},
-        metadata={"key": "value"},
+        extra={"key": "value"},
         children=[child],
     )
 

--- a/python/tests/treeviz/test__node_model.py
+++ b/python/tests/treeviz/test__node_model.py
@@ -19,7 +19,7 @@ def test_node_creation(assert_node):
     assert node.icon is None
 
     assert node.source_location is None
-    assert node.metadata == {}
+    assert node.extra == {}
 
 
 def test_node_with_all_fields(assert_node):
@@ -32,7 +32,7 @@ def test_node_with_all_fields(assert_node):
         icon="⧉",
         content_lines=5,
         source_location={"line": 10, "column": 5},
-        metadata={"key": "value"},
+        extra={"key": "value"},
         children=[child],
     )
 
@@ -44,7 +44,7 @@ def test_node_with_all_fields(assert_node):
         .has_icon("⧉")
         .has_content_lines(5)
         .has_source_location({"line": 10, "column": 5})
-        .has_metadata({"key": "value"})
+        .has_extra({"key": "value"})
         .has_children_count(1)
     )
 
@@ -71,22 +71,22 @@ def test_node_tree_structure(assert_node):
     assert branch.children[1] == leaf2
 
 
-def test_node_metadata_extensibility(assert_node):
-    """Test that metadata can store arbitrary data."""
-    metadata = {
+def test_node_extra_extensibility(assert_node):
+    """Test that extra can store arbitrary data."""
+    extra = {
         "custom_field": "value",
         "nested": {"inner": "data"},
         "list_data": [1, 2, 3],
         "boolean": True,
     }
 
-    node = Node(label="Test", metadata=metadata)
+    node = Node(label="Test", extra=extra)
 
-    # Use fluent assertion for metadata check
-    assert_node(node).has_metadata(metadata)
+    # Use fluent assertion for extra check
+    assert_node(node).has_extra(extra)
 
-    # Test individual metadata access
-    assert node.metadata["custom_field"] == "value"
-    assert node.metadata["nested"]["inner"] == "data"
-    assert node.metadata["list_data"] == [1, 2, 3]
-    assert node.metadata["boolean"] is True
+    # Test individual extra access
+    assert node.extra["custom_field"] == "value"
+    assert node.extra["nested"]["inner"] == "data"
+    assert node.extra["list_data"] == [1, 2, 3]
+    assert node.extra["boolean"] is True

--- a/test-docs/elements/annotations/annotation-simple.3viz.json
+++ b/test-docs/elements/annotations/annotation-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 10,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Basic annotation examples (paragraph)",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Basic annotation examples (paragraph)",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Basic annotation examples (paragraph)",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 37,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Single Annotatio:",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Single Annotatio:",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: author :: John Doe",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -89,7 +89,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Block:",
@@ -97,7 +97,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Block:",
@@ -105,7 +105,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -116,7 +116,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: author :: John Doe",
@@ -124,7 +124,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -135,7 +135,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: title :: Test Document ",
@@ -143,7 +143,7 @@
               "icon": null,
               "content_lines": 26,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -156,7 +156,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Empty label annotation:",
@@ -164,7 +164,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Empty label annotation:",
@@ -172,7 +172,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -183,7 +183,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "::  :: Empty label (annotation, label=\"\", value=\"Empty label\")",
@@ -191,7 +191,7 @@
               "icon": null,
               "content_lines": 62,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -204,7 +204,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Empty value annotation:",
@@ -212,7 +212,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Empty value annotation:",
@@ -220,7 +220,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -231,7 +231,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: status :: (annotation, label=\"status\", value=\"\")",
@@ -239,7 +239,7 @@
               "icon": null,
               "content_lines": 51,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -252,7 +252,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Multi-word label:",
@@ -260,7 +260,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Multi-word label:",
@@ -268,7 +268,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -279,7 +279,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: release notes :: Version 1.0 (annotation, label=\"release notes\", value=\"Version 1.0\")",
@@ -287,7 +287,7 @@
               "icon": null,
               "content_lines": 88,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -300,7 +300,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Annotation with parameters:",
@@ -308,7 +308,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Annotation with parameters:",
@@ -316,7 +316,7 @@
               "icon": null,
               "content_lines": 27,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -327,7 +327,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: meta:version=2.0 :: Document metadata (annotation, label=\"meta\", value=\"Document metadata\")",
@@ -335,7 +335,7 @@
               "icon": null,
               "content_lines": 94,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -348,7 +348,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Multiple parameters:",
@@ -356,7 +356,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Multiple parameters:",
@@ -364,7 +364,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -375,7 +375,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: config:mode=debug,level=verbose :: Configuration (annotation, label=\"config\", value=\"Configuration\")",
@@ -383,7 +383,7 @@
               "icon": null,
               "content_lines": 103,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -396,7 +396,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Quoted parameter values:",
@@ -404,7 +404,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Quoted parameter values:",
@@ -412,7 +412,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -423,7 +423,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: author:name=\"Jane Smith\",role=\"Editor\" :: Author info (annotation, label=\"author\", value=\"Author info\")",
@@ -431,7 +431,7 @@
               "icon": null,
               "content_lines": 106,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -444,7 +444,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Annotation-like content that isn't annotation:",
@@ -452,7 +452,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Annotation-like content that isn't annotation:",
@@ -460,7 +460,7 @@
               "icon": null,
               "content_lines": 46,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -471,7 +471,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is not :: an annotation :: because it's mid-line (paragraph)",
@@ -479,7 +479,7 @@
               "icon": null,
               "content_lines": 65,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/annotations/complex/annotation-attachment.3viz.json
+++ b/test-docs/elements/annotations/complex/annotation-attachment.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "First paragraph.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "First paragraph.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "First paragraph.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 16,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Second paragraph.",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Second paragraph.",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "We will not test thtat it attaches to a list-item correctly",
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "We will not test thtat it attaches to a list-item correctly",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 59,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -99,7 +99,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -110,7 +110,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -120,7 +120,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -131,7 +131,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -141,7 +141,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/annotations/complex/annotation-very-long.3viz.json
+++ b/test-docs/elements/annotations/complex/annotation-very-long.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 7,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Namespaced annotation::: txxt.internal:id=123 :: Internal marker (annotation, label=\"txxt.internal\", value=\"Internal marker\")",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Namespaced annotation:",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Namespaced annotation:",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: txxt.internal:id=123 :: Internal marker (annotation, label=\"txxt.internal\", value=\"Internal marker\")",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 103,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -60,7 +60,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Multi-line annotation:",
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Multi-line annotation:",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -87,7 +87,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: note ::",
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -106,7 +106,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    This is a longer annotation",
@@ -114,7 +114,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This is a longer annotation",
@@ -122,7 +122,7 @@
                   "icon": null,
                   "content_lines": 31,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -133,7 +133,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    that spans multiple lines",
@@ -141,7 +141,7 @@
                   "icon": null,
                   "content_lines": 29,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -152,7 +152,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    with indented content",
@@ -160,7 +160,7 @@
                   "icon": null,
                   "content_lines": 25,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -175,7 +175,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Expected: annotation with label=\"note\", value=\"This is a longer annotationnthat spans multiple linesnwith indented content\"",
@@ -183,7 +183,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Expected: annotation with label=\"note\", value=\"This is a longer annotationnthat spans multiple linesnwith indented content\"",
@@ -191,7 +191,7 @@
               "icon": null,
               "content_lines": 123,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -204,7 +204,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Content in the session (paragraph)",
@@ -212,7 +212,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Content in the session (paragraph)",
@@ -220,7 +220,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Content in the session (paragraph)",
@@ -228,7 +228,7 @@
                   "icon": null,
                   "content_lines": 38,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -243,7 +243,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Attached annotations (paragraph)",
@@ -251,7 +251,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Attached annotations (paragraph)",
@@ -259,7 +259,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -272,7 +272,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This paragraph has an annotation attached to it. (paragraph)",
@@ -280,7 +280,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This paragraph has an annotation attached to it. (paragraph)",
@@ -288,7 +288,7 @@
               "icon": null,
               "content_lines": 60,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -301,7 +301,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Document-level annotations at end:",
@@ -309,7 +309,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Document-level annotations at end:",
@@ -317,7 +317,7 @@
               "icon": null,
               "content_lines": 34,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/annotations/complex/annotation-with-params.3viz.json
+++ b/test-docs/elements/annotations/complex/annotation-with-params.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing parameter assertions in annotations",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing parameter assertions in annotations",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing parameter assertions in annotations",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 43,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/annotations/complex/annotation_at_end.3viz.json
+++ b/test-docs/elements/annotations/complex/annotation_at_end.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Some content here.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Some content here.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Some content here.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 18,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/annotations/complex/anotation-labels.3viz.json
+++ b/test-docs/elements/annotations/complex/anotation-labels.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Special characters in labels::: label-with-hyphens :: Hyphenated (annotation, label=\"label-with-hyphens\", value=\"Hyphenated\"):: labelunderscores :: Underscored (annotation, label=\"labelunderscores\", value=\"Underscored\") :: label.with.dots :: Dotted namespace (annotation, label=\"label.with.dots\", value=\"Dotted namespace\"):: UPPERCASE :: All caps (annotation, label=\"UPPERCASE\", value=\"All caps\"):: mixedCase123 :: Mixed with numbers (annotation, label=\"mixedCase123\", value=\"Mixed with numbers\")",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 6,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Special characters in labels:",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Special characters in labels:",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 29,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: label-with-hyphens :: Hyphenated (annotation, label=\"label-with-hyphens\", value=\"Hyphenated\")",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 96,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -58,7 +58,7 @@
           "icon": null,
           "content_lines": 5,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: label",
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 8,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -75,7 +75,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "with",
@@ -83,7 +83,7 @@
                   "icon": null,
                   "content_lines": 4,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -94,7 +94,7 @@
               "icon": null,
               "content_lines": 52,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -103,7 +103,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "with",
@@ -111,7 +111,7 @@
                   "icon": null,
                   "content_lines": 4,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -122,7 +122,7 @@
               "icon": null,
               "content_lines": 35,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -133,7 +133,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: label.with.dots :: Dotted namespace (annotation, label=\"label.with.dots\", value=\"Dotted namespace\")",
@@ -141,7 +141,7 @@
               "icon": null,
               "content_lines": 102,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -152,7 +152,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: UPPERCASE :: All caps (annotation, label=\"UPPERCASE\", value=\"All caps\")",
@@ -160,7 +160,7 @@
               "icon": null,
               "content_lines": 74,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -171,7 +171,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: mixedCase123 :: Mixed with numbers (annotation, label=\"mixedCase123\", value=\"Mixed with numbers\")",
@@ -179,7 +179,7 @@
               "icon": null,
               "content_lines": 100,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/content-container/complex/content-container-mixed.3viz.json
+++ b/test-docs/elements/content-container/complex/content-container-mixed.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "List",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -23,7 +23,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -33,7 +33,7 @@
               "icon": null,
               "content_lines": 43,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -42,7 +42,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -52,7 +52,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -60,7 +60,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -70,7 +70,7 @@
                           "icon": null,
                           "content_lines": 2,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        A definition uses ContentContainer to hold its content.",
@@ -78,7 +78,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        A definition uses ContentContainer to hold its content.",
@@ -86,7 +86,7 @@
                                   "icon": null,
                                   "content_lines": 63,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -97,7 +97,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        This allows for consistent structure across all indented content.",
@@ -105,7 +105,7 @@
                                   "icon": null,
                                   "content_lines": 73,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -122,7 +122,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -130,7 +130,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -140,7 +140,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Definitions can contain multiple block types:",
@@ -148,7 +148,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Definitions can contain multiple block types:",
@@ -156,7 +156,7 @@
                                   "icon": null,
                                   "content_lines": 53,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -169,7 +169,7 @@
                           "icon": null,
                           "content_lines": 3,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "ordered": false,
                             "style": "unordered"
                           },
@@ -180,7 +180,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -190,7 +190,7 @@
                                   "icon": null,
                                   "content_lines": 31,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -201,7 +201,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -211,7 +211,7 @@
                                   "icon": null,
                                   "content_lines": 40,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -222,7 +222,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -232,7 +232,7 @@
                                   "icon": null,
                                   "content_lines": 44,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -245,7 +245,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        All wrapped in a ContentContainer.",
@@ -253,7 +253,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        All wrapped in a ContentContainer.",
@@ -261,7 +261,7 @@
                                   "icon": null,
                                   "content_lines": 42,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -284,7 +284,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -295,7 +295,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -305,7 +305,7 @@
               "icon": null,
               "content_lines": 54,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -314,7 +314,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": []
@@ -329,7 +329,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -340,7 +340,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "3."
           },
           "children": [
@@ -350,7 +350,7 @@
               "icon": null,
               "content_lines": 28,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -359,7 +359,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -369,7 +369,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -377,7 +377,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -387,7 +387,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        This definition contains nested structures.",
@@ -395,7 +395,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        This definition contains nested structures.",
@@ -403,7 +403,7 @@
                                   "icon": null,
                                   "content_lines": 51,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -416,7 +416,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "Content",
@@ -424,7 +424,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "indent": 9
                               },
                               "children": [
@@ -434,7 +434,7 @@
                                   "icon": null,
                                   "content_lines": 2,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "            Nested definitions work as expected.",
@@ -442,7 +442,7 @@
                                       "icon": null,
                                       "content_lines": 1,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": [
                                         {
                                           "label": "            Nested definitions work as expected.",
@@ -450,7 +450,7 @@
                                           "icon": null,
                                           "content_lines": 48,
                                           "source_location": null,
-                                          "metadata": {},
+                                          "extra": {},
                                           "children": []
                                         }
                                       ]
@@ -461,7 +461,7 @@
                                       "icon": null,
                                       "content_lines": 1,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": [
                                         {
                                           "label": "            Each has its own ContentContainer.",
@@ -469,7 +469,7 @@
                                           "icon": null,
                                           "content_lines": 46,
                                           "source_location": null,
-                                          "metadata": {},
+                                          "extra": {},
                                           "children": []
                                         }
                                       ]
@@ -486,7 +486,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Back to the outer definition content.",
@@ -494,7 +494,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Back to the outer definition content.",
@@ -502,7 +502,7 @@
                                   "icon": null,
                                   "content_lines": 45,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -525,7 +525,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Empty Definition ::",
@@ -533,7 +533,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Empty Definition ::",
@@ -541,7 +541,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Empty Definition ::",
@@ -549,7 +549,7 @@
                   "icon": null,
                   "content_lines": 23,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -562,7 +562,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Content",
@@ -570,7 +570,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 5
               },
               "children": [
@@ -580,7 +580,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Single line content.",
@@ -588,7 +588,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        Single line content.",
@@ -596,7 +596,7 @@
                           "icon": null,
                           "content_lines": 28,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]

--- a/test-docs/elements/content-container/content-container.simple.3viz.json
+++ b/test-docs/elements/content-container/content-container.simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "List",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -23,7 +23,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -33,7 +33,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -42,7 +42,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -52,7 +52,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -60,7 +60,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -70,7 +70,7 @@
                           "icon": null,
                           "content_lines": 2,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        A definition uses ContentContainer to hold its content.",
@@ -78,7 +78,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        A definition uses ContentContainer to hold its content.",
@@ -86,7 +86,7 @@
                                   "icon": null,
                                   "content_lines": 63,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -97,7 +97,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        This allows for consistent structure across all indented content.",
@@ -105,7 +105,7 @@
                                   "icon": null,
                                   "content_lines": 73,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -122,7 +122,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -130,7 +130,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -140,7 +140,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Definitions can contain multiple block types:",
@@ -148,7 +148,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Definitions can contain multiple block types:",
@@ -156,7 +156,7 @@
                                   "icon": null,
                                   "content_lines": 53,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -169,7 +169,7 @@
                           "icon": null,
                           "content_lines": 3,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "ordered": false,
                             "style": "unordered"
                           },
@@ -180,7 +180,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -190,7 +190,7 @@
                                   "icon": null,
                                   "content_lines": 20,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -201,7 +201,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -211,7 +211,7 @@
                                   "icon": null,
                                   "content_lines": 29,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -222,7 +222,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -232,7 +232,7 @@
                                   "icon": null,
                                   "content_lines": 33,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -245,7 +245,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        All wrapped in a ContentContainer.",
@@ -253,7 +253,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        All wrapped in a ContentContainer.",
@@ -261,7 +261,7 @@
                                   "icon": null,
                                   "content_lines": 42,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -278,7 +278,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -286,7 +286,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -296,7 +296,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        First paragraph of the definition.",
@@ -304,7 +304,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        First paragraph of the definition.",
@@ -312,7 +312,7 @@
                                   "icon": null,
                                   "content_lines": 42,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -325,7 +325,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Second paragraph, separated by a blank line.",
@@ -333,7 +333,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Second paragraph, separated by a blank line.",
@@ -341,7 +341,7 @@
                                   "icon": null,
                                   "content_lines": 52,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -354,7 +354,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Third paragraph with emphasis on structure.",
@@ -362,7 +362,7 @@
                               "icon": null,
                               "content_lines": 3,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Third paragraph with emphasis on ",
@@ -370,7 +370,7 @@
                                   "icon": null,
                                   "content_lines": 41,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 },
                                 {
@@ -379,7 +379,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "structure",
@@ -387,7 +387,7 @@
                                       "icon": null,
                                       "content_lines": 9,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -398,7 +398,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -421,7 +421,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -432,7 +432,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -442,7 +442,7 @@
               "icon": null,
               "content_lines": 43,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -451,7 +451,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": []
@@ -466,7 +466,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -477,7 +477,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "3."
           },
           "children": [
@@ -487,7 +487,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -496,7 +496,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -506,7 +506,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "Content",
@@ -514,7 +514,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -524,7 +524,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        This definition contains nested structures.",
@@ -532,7 +532,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        This definition contains nested structures.",
@@ -540,7 +540,7 @@
                                   "icon": null,
                                   "content_lines": 51,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -553,7 +553,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "Content",
@@ -561,7 +561,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "indent": 9
                               },
                               "children": [
@@ -571,7 +571,7 @@
                                   "icon": null,
                                   "content_lines": 2,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "            Nested definitions work as expected.",
@@ -579,7 +579,7 @@
                                       "icon": null,
                                       "content_lines": 1,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": [
                                         {
                                           "label": "            Nested definitions work as expected.",
@@ -587,7 +587,7 @@
                                           "icon": null,
                                           "content_lines": 48,
                                           "source_location": null,
-                                          "metadata": {},
+                                          "extra": {},
                                           "children": []
                                         }
                                       ]
@@ -598,7 +598,7 @@
                                       "icon": null,
                                       "content_lines": 1,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": [
                                         {
                                           "label": "            Each has its own ContentContainer.",
@@ -606,7 +606,7 @@
                                           "icon": null,
                                           "content_lines": 46,
                                           "source_location": null,
-                                          "metadata": {},
+                                          "extra": {},
                                           "children": []
                                         }
                                       ]
@@ -623,7 +623,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Back to the outer definition content.",
@@ -631,7 +631,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Back to the outer definition content.",
@@ -639,7 +639,7 @@
                                   "icon": null,
                                   "content_lines": 45,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -662,7 +662,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Empty Definition ::",
@@ -670,7 +670,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Empty Definition ::",
@@ -678,7 +678,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Empty Definition ::",
@@ -686,7 +686,7 @@
                   "icon": null,
                   "content_lines": 23,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -699,7 +699,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Content",
@@ -707,7 +707,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 5
               },
               "children": [
@@ -717,7 +717,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Single line content.",
@@ -725,7 +725,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        Single line content.",
@@ -733,7 +733,7 @@
                           "icon": null,
                           "content_lines": 28,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]

--- a/test-docs/elements/definitions/complex/definitions-nested.3viz.json
+++ b/test-docs/elements/definitions/complex/definitions-nested.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Definition",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 5,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -30,7 +30,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Definitions has at least one line of content.",
@@ -38,7 +38,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Definitions has at least one line of content.",
@@ -46,7 +46,7 @@
                       "icon": null,
                       "content_lines": 49,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -59,7 +59,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    But can have more.",
@@ -67,7 +67,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    But can have more.",
@@ -75,7 +75,7 @@
                       "icon": null,
                       "content_lines": 22,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -88,7 +88,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Including other types: ",
@@ -96,7 +96,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Including other types: ",
@@ -104,7 +104,7 @@
                       "icon": null,
                       "content_lines": 27,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -117,7 +117,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -128,7 +128,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -138,7 +138,7 @@
                       "icon": null,
                       "content_lines": 17,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -149,7 +149,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -159,7 +159,7 @@
                       "icon": null,
                       "content_lines": 11,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -168,7 +168,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 5
                       },
                       "children": [
@@ -178,7 +178,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "ordered": false,
                             "style": "unordered"
                           },
@@ -189,7 +189,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "-"
                               },
                               "children": [
@@ -199,7 +199,7 @@
                                   "icon": null,
                                   "content_lines": 33,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -216,7 +216,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -226,7 +226,7 @@
                       "icon": null,
                       "content_lines": 17,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -239,7 +239,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "Content",
@@ -247,7 +247,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "indent": 5
                   },
                   "children": [
@@ -257,7 +257,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        This is a nested definition inside the outer definition",
@@ -265,7 +265,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        This is a nested definition inside the outer definition",
@@ -273,7 +273,7 @@
                               "icon": null,
                               "content_lines": 63,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]

--- a/test-docs/elements/definitions/definition-basic.3viz.json
+++ b/test-docs/elements/definitions/definition-basic.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Definition",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -30,7 +30,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Definition content here",
@@ -38,7 +38,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Definition content here",
@@ -46,7 +46,7 @@
                       "icon": null,
                       "content_lines": 27,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/elements/definitions/definition-complex.3viz.json
+++ b/test-docs/elements/definitions/definition-complex.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Definition",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -30,7 +30,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    A definition containing a list:",
@@ -38,7 +38,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    A definition containing a list:",
@@ -46,7 +46,7 @@
                       "icon": null,
                       "content_lines": 35,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -59,7 +59,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -70,7 +70,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -80,7 +80,7 @@
                       "icon": null,
                       "content_lines": 16,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -91,7 +91,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -101,7 +101,7 @@
                       "icon": null,
                       "content_lines": 19,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -112,7 +112,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -122,7 +122,7 @@
                       "icon": null,
                       "content_lines": 16,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -139,7 +139,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -147,7 +147,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -157,7 +157,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    First paragraph of content.",
@@ -165,7 +165,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    First paragraph of content.",
@@ -173,7 +173,7 @@
                       "icon": null,
                       "content_lines": 31,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -186,7 +186,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Second paragraph in the same definition.",
@@ -194,7 +194,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Second paragraph in the same definition.",
@@ -202,7 +202,7 @@
                       "icon": null,
                       "content_lines": 44,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -215,7 +215,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Third paragraph still in definition.",
@@ -223,7 +223,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Third paragraph still in definition.",
@@ -231,7 +231,7 @@
                       "icon": null,
                       "content_lines": 40,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -248,7 +248,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -256,7 +256,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -266,7 +266,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "Here is some code",
                 "label": "",
                 "parameters": {},
@@ -280,7 +280,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    python:",
@@ -288,7 +288,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    python:",
@@ -296,7 +296,7 @@
                       "icon": null,
                       "content_lines": 11,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -309,7 +309,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    After the code block.",
@@ -317,7 +317,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    After the code block.",
@@ -325,7 +325,7 @@
                       "icon": null,
                       "content_lines": 25,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -342,7 +342,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -350,7 +350,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -360,7 +360,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Definition with bold text and italic content.",
@@ -368,7 +368,7 @@
                   "icon": null,
                   "content_lines": 5,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Definition with ",
@@ -376,7 +376,7 @@
                       "icon": null,
                       "content_lines": 20,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -385,7 +385,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "bold text",
@@ -393,7 +393,7 @@
                           "icon": null,
                           "content_lines": 9,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -404,7 +404,7 @@
                       "icon": null,
                       "content_lines": 5,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -413,7 +413,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "italic",
@@ -421,7 +421,7 @@
                           "icon": null,
                           "content_lines": 6,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -432,7 +432,7 @@
                       "icon": null,
                       "content_lines": 9,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/elements/definitions/definition-edge-cases.3viz.json
+++ b/test-docs/elements/definitions/definition-edge-cases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 5,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Definition",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -30,7 +30,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This is a definition.",
@@ -38,7 +38,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    This is a definition.",
@@ -46,7 +46,7 @@
                       "icon": null,
                       "content_lines": 25,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -63,7 +63,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -71,7 +71,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -81,7 +81,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Term can contain :: within it.",
@@ -89,7 +89,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Term can contain :: within it.",
@@ -97,7 +97,7 @@
                       "icon": null,
                       "content_lines": 34,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -114,7 +114,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -122,7 +122,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -132,7 +132,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This definition ends when",
@@ -140,7 +140,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    This definition ends when",
@@ -148,7 +148,7 @@
                       "icon": null,
                       "content_lines": 29,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -159,7 +159,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    we return to lesser indentation.",
@@ -167,7 +167,7 @@
                       "icon": null,
                       "content_lines": 36,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -184,7 +184,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -192,7 +192,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -202,7 +202,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This is separate.",
@@ -210,7 +210,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    This is separate.",
@@ -218,7 +218,7 @@
                       "icon": null,
                       "content_lines": 21,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -235,7 +235,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -243,7 +243,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -253,7 +253,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    The term has inline elements.",
@@ -261,7 +261,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    The term has inline elements.",
@@ -269,7 +269,7 @@
                       "icon": null,
                       "content_lines": 33,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/elements/definitions/definition-simple.3viz.json
+++ b/test-docs/elements/definitions/definition-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 5,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Definition",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -30,7 +30,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    A simple definition on a single line.",
@@ -38,7 +38,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    A simple definition on a single line.",
@@ -46,7 +46,7 @@
                       "icon": null,
                       "content_lines": 41,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -63,7 +63,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -71,7 +71,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -81,7 +81,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    A program that analyzes text ",
@@ -89,7 +89,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    A program that analyzes text ",
@@ -97,7 +97,7 @@
                       "icon": null,
                       "content_lines": 33,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -108,7 +108,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    according to formal grammar rules.",
@@ -116,7 +116,7 @@
                       "icon": null,
                       "content_lines": 38,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -133,7 +133,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -141,7 +141,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -151,7 +151,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Definition with bold in the term.",
@@ -159,7 +159,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Definition with bold in the term.",
@@ -167,7 +167,7 @@
                       "icon": null,
                       "content_lines": 37,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -184,7 +184,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -192,7 +192,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -202,7 +202,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    First definition content.",
@@ -210,7 +210,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    First definition content.",
@@ -218,7 +218,7 @@
                       "icon": null,
                       "content_lines": 29,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -235,7 +235,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Content",
@@ -243,7 +243,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "indent": 1
           },
           "children": [
@@ -253,7 +253,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Second definition content.",
@@ -261,7 +261,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    Second definition content.",
@@ -269,7 +269,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/elements/inline/complex/inline-nested.3viz.json
+++ b/test-docs/elements/inline/complex/inline-nested.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This has  text.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This has bold with {{strong}} text.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This has ",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 9,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -37,7 +37,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "bold with ",
@@ -45,7 +45,7 @@
                   "icon": null,
                   "content_lines": 10,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -54,7 +54,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "nested italic {{emphasis}}",
@@ -62,7 +62,7 @@
                       "icon": null,
                       "content_lines": 26,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -73,7 +73,7 @@
                   "icon": null,
                   "content_lines": 10,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -84,7 +84,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -97,7 +97,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Paragraph with emphasis {{paragraph.strong}}.",
@@ -105,7 +105,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Paragraph with ",
@@ -113,7 +113,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -122,7 +122,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "emphasis {{paragraph.strong}}",
@@ -130,7 +130,7 @@
                   "icon": null,
                   "content_lines": 29,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -141,7 +141,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/inline/complex/inline-parent-assertions.3viz.json
+++ b/test-docs/elements/inline/complex/inline-parent-assertions.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing various assertion styles",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing various assertion styles",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing various assertion styles",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This has bold text {{strong}} in a paragraph.",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This has ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 9,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "bold text {{strong}}",
@@ -74,7 +74,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -85,7 +85,7 @@
               "icon": null,
               "content_lines": 16,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -98,7 +98,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "List item with emphasis {{emphasis}} text",
@@ -106,7 +106,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "List item with ",
@@ -114,7 +114,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -123,7 +123,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "emphasis {{emphasis}}",
@@ -131,7 +131,7 @@
                   "icon": null,
                   "content_lines": 21,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -142,7 +142,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -155,7 +155,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing attributes on annotations:",
@@ -163,7 +163,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing attributes on annotations:",
@@ -171,7 +171,7 @@
               "icon": null,
               "content_lines": 34,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/inline/complex/inline-text-content.3viz.json
+++ b/test-docs/elements/inline/complex/inline-text-content.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing text content and TextLine structure",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing text content and TextLine structure",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing text content and TextLine structure",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 43,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This paragraph contains text {{paragraph}}",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This paragraph contains text {{paragraph}}",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 42,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "The textLine structure {{paragraph.textLine}}",
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The textLine structure {{paragraph.textLine}}",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 45,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -99,7 +99,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "With formatted {{strong}} content inside {{paragraph}}",
@@ -107,7 +107,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "With ",
@@ -115,7 +115,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -124,7 +124,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "formatted {{strong}}",
@@ -132,7 +132,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -143,7 +143,7 @@
               "icon": null,
               "content_lines": 29,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/inline/inline-simple.3viz.json
+++ b/test-docs/elements/inline/inline-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 5,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is only one inline ",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is only one inline bold {{strong}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is only one inline ",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -37,7 +37,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "bold {{strong}}",
@@ -45,7 +45,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -60,7 +60,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is only one inline italic {{emphasis}}",
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is only one inline ",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -85,7 +85,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "italic {{emphasis}}",
@@ -93,7 +93,7 @@
                   "icon": null,
                   "content_lines": 19,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -108,7 +108,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is only one inline code {{code}}",
@@ -116,7 +116,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is only one inline ",
@@ -124,7 +124,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -133,7 +133,7 @@
               "icon": null,
               "content_lines": 13,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -146,7 +146,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This one is only math ",
@@ -154,7 +154,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This one is only math ",
@@ -162,7 +162,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -171,7 +171,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -184,7 +184,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This has bold {{strong}} and italic {{emphasis}} text.",
@@ -192,7 +192,7 @@
           "icon": null,
           "content_lines": 5,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This has ",
@@ -200,7 +200,7 @@
               "icon": null,
               "content_lines": 9,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -209,7 +209,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "bold {{strong}}",
@@ -217,7 +217,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -228,7 +228,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -237,7 +237,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "italic {{emphasis}}",
@@ -245,7 +245,7 @@
                   "icon": null,
                   "content_lines": 19,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -256,7 +256,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/inline/math/inline-math-complex.3viz.json
+++ b/test-docs/elements/inline/math/inline-math-complex.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Greek leters tough #",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Greek leters tough #",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Greek leters tough ",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -37,7 +37,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -46,7 +46,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/inline/references/complex/inline-reference-citation.3viz.json
+++ b/test-docs/elements/inline/references/complex/inline-reference-citation.3viz.json
@@ -4,6 +4,6 @@
   "icon": null,
   "content_lines": 0,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": []
 }

--- a/test-docs/elements/inline/references/complex/inline-reference-path.3viz.json
+++ b/test-docs/elements/inline/references/complex/inline-reference-path.3viz.json
@@ -4,6 +4,6 @@
   "icon": null,
   "content_lines": 0,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": []
 }

--- a/test-docs/elements/inline/references/complex/inline-reference-session.3viz.json
+++ b/test-docs/elements/inline/references/complex/inline-reference-session.3viz.json
@@ -4,6 +4,6 @@
   "icon": null,
   "content_lines": 0,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": []
 }

--- a/test-docs/elements/inline/references/complex/inline-reference-url.3viz.json
+++ b/test-docs/elements/inline/references/complex/inline-reference-url.3viz.json
@@ -4,6 +4,6 @@
   "icon": null,
   "content_lines": 0,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": []
 }

--- a/test-docs/elements/inline/references/reference-simple.3viz.json
+++ b/test-docs/elements/inline/references/reference-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 6,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is only a preliminary tests for references , and each type should have it's own files.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is only a preliminary tests for references , and each type should have it's own files.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is only a preliminary tests for references , and each type should have it's own files.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 91,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a url reference [UrlRefTarget(type='urlRefTarget', position=None, data={}, raw_content='http://example.com', icon='↗', url='http://example.com', protocol='http')]",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a url reference ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -79,7 +79,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a path reference [PathRefTarget(type='pathRefTarget', position=None, data={}, raw_content='./path', icon='/', path='./path')]",
@@ -87,7 +87,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a path reference ",
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -117,7 +117,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a inner sesson reference [SessionRefTarget(type='sessionRefTarget', position=None, data={}, raw_content='#3', icon='§', session_id='3')]",
@@ -125,7 +125,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a inner sesson reference ",
@@ -133,7 +133,7 @@
               "icon": null,
               "content_lines": 33,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -142,7 +142,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -155,7 +155,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a footnote reference (in which a session is 0, which is the last one) , this is the 3rd footnote [FootnoteRefTarget(type='footnoteRefTarget', position=None, data={}, raw_content='3', icon='¹', number=3, has_caret=False)]",
@@ -163,7 +163,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a footnote reference (in which a session is 0, which is the last one) , this is the 3rd footnote ",
@@ -171,7 +171,7 @@
               "icon": null,
               "content_lines": 105,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -180,7 +180,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -193,7 +193,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a citation ",
@@ -201,7 +201,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a citation ",
@@ -209,7 +209,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -218,7 +218,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-blank-line-separation.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-blank-line-separation.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing list separation rules with blank lines, and that we should 3 different lists",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing list separation rules with blank lines, and that we should 3 different lists",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing list separation rules with blank lines, and that we should 3 different lists",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 84,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 6,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 29,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -94,7 +94,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -115,7 +115,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -125,7 +125,7 @@
               "icon": null,
               "content_lines": 38,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -136,7 +136,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -146,7 +146,7 @@
               "icon": null,
               "content_lines": 41,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -157,7 +157,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -167,7 +167,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-complex-inline-elements.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-complex-inline-elements.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing list items with complex inline elements",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing list items with complex inline elements",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing list items with complex inline elements",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 47,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 5,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -71,7 +71,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "emphasis",
@@ -79,7 +79,7 @@
                   "icon": null,
                   "content_lines": 8,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -90,7 +90,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -99,7 +99,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "strong",
@@ -107,7 +107,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "strong",
@@ -115,7 +115,7 @@
                       "icon": null,
                       "content_lines": 6,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -128,7 +128,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -139,7 +139,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -149,7 +149,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -158,7 +158,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -167,7 +167,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -178,7 +178,7 @@
           "icon": null,
           "content_lines": 4,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -188,7 +188,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -197,7 +197,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -206,7 +206,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -215,7 +215,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -226,7 +226,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -236,7 +236,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-custom-bullets.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-custom-bullets.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing custom bullet markers, which should not workt, we want to ensure that the next element is one paragraph (not a list) not many paragraphs.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing custom bullet markers, which should not workt, we want to ensure that the next element is one paragraph (not a list) not many paragraphs.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing custom bullet markers, which should not workt, we want to ensure that the next element is one paragraph (not a list) not many paragraphs.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 145,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "➤ Arrow bullet item ",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "➤ Arrow bullet item ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "➤ Another arrow item ",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -87,7 +87,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "* Asterisk bullet item ",
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -106,7 +106,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "* Another asterisk item  {{paragraph}}",
@@ -114,7 +114,7 @@
               "icon": null,
               "content_lines": 38,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-empty-items.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-empty-items.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing how parser handles empty list items",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing how parser handles empty list items",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing how parser handles empty list items",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 43,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "- ",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "- ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -81,7 +81,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -91,7 +91,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -102,7 +102,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -112,7 +112,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -125,7 +125,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "- ",
@@ -133,7 +133,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "- ",
@@ -141,7 +141,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-first-marker-style.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-first-marker-style.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing spec 6.1: first marker determines list style",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing spec 6.1: first marker determines list style",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing spec 6.1: first marker determines list style",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 52,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 30,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 28,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -94,7 +94,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "a)"
           },
           "children": [
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-no-blank-line.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-no-blank-line.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "A list that has no blank line from a paragraph is still a list:",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "A list that has no blank line from a paragraph is still a list:",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "A list that has no blank line from a paragraph is still a list:",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 63,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -71,7 +71,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -81,7 +81,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": true,
                     "style": "ordered-numeric"
                   },
@@ -92,7 +92,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "2."
                       },
                       "children": [
@@ -102,7 +102,7 @@
                           "icon": null,
                           "content_lines": 20,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -119,7 +119,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -129,7 +129,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -138,7 +138,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -148,7 +148,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -159,7 +159,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -169,7 +169,7 @@
                           "icon": null,
                           "content_lines": 19,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -188,7 +188,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "A list that has no blank line from a paragraph is still a list:",
@@ -196,7 +196,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "A list that has no blank line from a paragraph is still a list:",
@@ -204,7 +204,7 @@
               "icon": null,
               "content_lines": 63,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-non-sequential-numbering.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-non-sequential-numbering.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing marker preservation with non-sequential numbering",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing marker preservation with non-sequential numbering",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing marker preservation with non-sequential numbering",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 57,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "3."
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -94,7 +94,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "a)"
           },
           "children": [
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -115,7 +115,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -125,7 +125,7 @@
               "icon": null,
               "content_lines": 9,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-qualified-numbering.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-qualified-numbering.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing fully qualified decimal numbering",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing fully qualified decimal numbering",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing fully qualified decimal numbering",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 41,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "1.1. First sub-item",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "1.1. First sub-item",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "1.2. Second sub-item",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -87,7 +87,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "2.1. Another section first",
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 26,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -106,7 +106,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "2.1.1. Deeply nested item",
@@ -114,7 +114,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-unicode-emoji.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-unicode-emoji.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing Unicode and special characters in list items",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing Unicode and special characters in list items",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing Unicode and special characters in list items",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 52,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 13,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -94,7 +94,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -115,7 +115,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -125,7 +125,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/commplex/lists-very-long-lines.3viz.json
+++ b/test-docs/elements/lists/commplex/lists-very-long-lines.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Testing very long single-line items for wrapping behavior",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Testing very long single-line items for wrapping behavior",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Testing very long single-line items for wrapping behavior",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 57,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 339,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/list-basic.3viz.json
+++ b/test-docs/elements/lists/list-basic.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is the unorderd style: ",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is the unorderd style: ",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the unorderd style: ",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 28,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 35,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 36,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -94,7 +94,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -104,7 +104,7 @@
               "icon": null,
               "content_lines": 31,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -115,7 +115,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -125,7 +125,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -138,7 +138,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is the ordered syle:",
@@ -146,7 +146,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the ordered syle:",
@@ -154,7 +154,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/list-simple.3viz.json
+++ b/test-docs/elements/lists/list-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 13,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Basic list examples (paragraph)",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Basic list examples (paragraph)",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Basic list examples (paragraph)",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 31,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Simple unordered list:",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Simple unordered list:",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 6,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -81,7 +81,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -91,7 +91,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -102,7 +102,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -112,7 +112,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -123,7 +123,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -133,7 +133,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -144,7 +144,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -154,7 +154,7 @@
               "icon": null,
               "content_lines": 31,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -165,7 +165,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -175,7 +175,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -186,7 +186,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "3."
           },
           "children": [
@@ -196,7 +196,7 @@
               "icon": null,
               "content_lines": 31,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -209,7 +209,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Simple ordered list:",
@@ -217,7 +217,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Simple ordered list:",
@@ -225,7 +225,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -238,7 +238,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Alphabetic list:",
@@ -246,7 +246,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Alphabetic list:",
@@ -254,7 +254,7 @@
               "icon": null,
               "content_lines": 16,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -267,7 +267,7 @@
       "icon": null,
       "content_lines": 5,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-alpha"
       },
@@ -278,7 +278,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "a."
           },
           "children": [
@@ -288,7 +288,7 @@
               "icon": null,
               "content_lines": 28,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -299,7 +299,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "b."
           },
           "children": [
@@ -309,7 +309,7 @@
               "icon": null,
               "content_lines": 29,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -320,7 +320,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "c."
           },
           "children": [
@@ -330,7 +330,7 @@
               "icon": null,
               "content_lines": 28,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -341,7 +341,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -351,7 +351,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -360,7 +360,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -370,7 +370,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -381,7 +381,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -391,7 +391,7 @@
                           "icon": null,
                           "content_lines": 33,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -402,7 +402,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -412,7 +412,7 @@
                           "icon": null,
                           "content_lines": 33,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -429,7 +429,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -439,7 +439,7 @@
               "icon": null,
               "content_lines": 31,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -452,7 +452,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "List with nested items:",
@@ -460,7 +460,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "List with nested items:",
@@ -468,7 +468,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -481,7 +481,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Mixed depth list:",
@@ -489,7 +489,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Mixed depth list:",
@@ -497,7 +497,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -510,7 +510,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -521,7 +521,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -531,7 +531,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -540,7 +540,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -550,7 +550,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": true,
                     "style": "ordered-alpha"
                   },
@@ -561,7 +561,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "a."
                       },
                       "children": [
@@ -571,7 +571,7 @@
                           "icon": null,
                           "content_lines": 31,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -580,7 +580,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "indent": 5
                           },
                           "children": [
@@ -590,7 +590,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "ordered": false,
                                 "style": "unordered"
                               },
@@ -601,7 +601,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {
+                                  "extra": {
                                     "marker": "-"
                                   },
                                   "children": [
@@ -611,7 +611,7 @@
                                       "icon": null,
                                       "content_lines": 33,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -628,7 +628,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "b."
                       },
                       "children": [
@@ -638,7 +638,7 @@
                           "icon": null,
                           "content_lines": 33,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -655,7 +655,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -665,7 +665,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -678,7 +678,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "List",
@@ -686,7 +686,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -697,7 +697,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -707,7 +707,7 @@
                   "icon": null,
                   "content_lines": 33,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -718,7 +718,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -728,7 +728,7 @@
                   "icon": null,
                   "content_lines": 30,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -741,7 +741,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "List",
@@ -749,7 +749,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": true,
                 "style": "ordered-numeric"
               },
@@ -760,7 +760,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "1."
                   },
                   "children": [
@@ -770,7 +770,7 @@
                       "icon": null,
                       "content_lines": 47,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -781,7 +781,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "2."
                   },
                   "children": [
@@ -791,7 +791,7 @@
                       "icon": null,
                       "content_lines": 38,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -808,7 +808,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Multi-line list items:",
@@ -816,7 +816,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Multi-line list items:",
@@ -824,7 +824,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -837,7 +837,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -848,7 +848,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -858,7 +858,7 @@
               "icon": null,
               "content_lines": 26,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -867,7 +867,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -877,7 +877,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    that spans multiple lines",
@@ -885,7 +885,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "    that spans multiple lines",
@@ -893,7 +893,7 @@
                           "icon": null,
                           "content_lines": 29,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -904,7 +904,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "    but is still one item (list-item)",
@@ -912,7 +912,7 @@
                           "icon": null,
                           "content_lines": 37,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -929,7 +929,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -939,7 +939,7 @@
               "icon": null,
               "content_lines": 33,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -950,7 +950,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -960,7 +960,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -971,7 +971,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -981,7 +981,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -994,7 +994,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "List immediately after paragraph:",
@@ -1002,7 +1002,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "List immediately after paragraph:",
@@ -1010,7 +1010,7 @@
               "icon": null,
               "content_lines": 33,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/lists/lists-edgecases.3viz.json
+++ b/test-docs/elements/lists/lists-edgecases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 11,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This document will test variations on list parsing. And can be run as an auto test (see conftest.py), where the content ends with <parens><element name><parens> and can be verified automatically (paragraph)",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This document will test variations on list parsing. ",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This document will test variations on list parsing. ",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 52,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "And can be run as an auto test (see conftest.py), where the content ends with <parens><element name><parens> and can be verified automatically (paragraph)",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 154,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -60,7 +60,7 @@
       "icon": null,
       "content_lines": 6,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -71,7 +71,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -81,7 +81,7 @@
               "icon": null,
               "content_lines": 65,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -92,7 +92,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -102,7 +102,7 @@
               "icon": null,
               "content_lines": 42,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -113,7 +113,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -123,7 +123,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -134,7 +134,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -144,7 +144,7 @@
               "icon": null,
               "content_lines": 61,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -153,7 +153,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -163,7 +163,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -174,7 +174,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -184,7 +184,7 @@
                           "icon": null,
                           "content_lines": 28,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -201,7 +201,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -211,7 +211,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -222,7 +222,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -232,7 +232,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -245,7 +245,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "A list that has no blank line from a paragraph is still a list:  (paragraph)",
@@ -253,7 +253,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "A list that has no blank line from a paragraph is still a list:  (paragraph)",
@@ -261,7 +261,7 @@
               "icon": null,
               "content_lines": 76,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -274,7 +274,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "A list that has no blank line from a paragraph is still a list:  (paragraph)",
@@ -282,7 +282,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "A list that has no blank line from a paragraph is still a list:  (paragraph)",
@@ -290,7 +290,7 @@
               "icon": null,
               "content_lines": 76,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -303,7 +303,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -314,7 +314,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -324,7 +324,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -333,7 +333,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -343,7 +343,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -354,7 +354,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -364,7 +364,7 @@
                           "icon": null,
                           "content_lines": 31,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -381,7 +381,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -391,7 +391,7 @@
               "icon": null,
               "content_lines": 65,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -402,7 +402,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -412,7 +412,7 @@
               "icon": null,
               "content_lines": 58,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -423,7 +423,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -433,7 +433,7 @@
               "icon": null,
               "content_lines": 98,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -446,7 +446,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "But the single element rule still applies (paragraph)",
@@ -454,7 +454,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "But the single element rule still applies (paragraph)",
@@ -462,7 +462,7 @@
               "icon": null,
               "content_lines": 53,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -475,7 +475,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "We allow an escape hatch, a way to represent dialogs without them being interpreted as lists. This is done by adding a period after the first line's end-punctuation mark (paragraph)",
@@ -483,7 +483,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "We allow an escape hatch, a way to represent dialogs without them being interpreted as lists. This is done by adding a period after the first line's end-punctuation mark (paragraph)",
@@ -491,7 +491,7 @@
               "icon": null,
               "content_lines": 181,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -504,7 +504,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "For all end-punctuations, just add a period, like in !!. ",
@@ -512,7 +512,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "For all end-punctuations, just add a period, like in !!. ",
@@ -520,7 +520,7 @@
               "icon": null,
               "content_lines": 57,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -533,7 +533,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This should be a paragraph too (paragraph)",
@@ -541,7 +541,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This should be a paragraph too (paragraph)",
@@ -549,7 +549,7 @@
               "icon": null,
               "content_lines": 42,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -562,7 +562,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "this should be a list",
@@ -570,7 +570,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "this should be a list",
@@ -578,7 +578,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -591,7 +591,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "yes (list-item)",
@@ -599,7 +599,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "yes (list-item)",
@@ -607,7 +607,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/paragraph/complex/paragraph-dialog-escape-period.3viz.json
+++ b/test-docs/elements/paragraph/complex/paragraph-dialog-escape-period.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 9,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "We allow an escape hatch, a way to represent dialogs without them being interpreted as lists. This is done by adding a period after the first line's end-punctuation mark This file has several such cases, they all should be parsed as pargraphs. and that each one is a pargraph",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "We allow an escape hatch, a way to represent dialogs without them being interpreted as lists. This is done by adding a period after the first line's end-punctuation mark This file has several such cases, they all should be parsed as pargraphs. and that each one is a pargraph",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "We allow an escape hatch, a way to represent dialogs without them being interpreted as lists. This is done by adding a period after the first line's end-punctuation mark This file has several such cases, they all should be parsed as pargraphs. and that each one is a pargraph",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 275,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is actually a dialog, hence, paragraph, not a list.. ",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is actually a dialog, hence, paragraph, not a list.. ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 58,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 73,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -99,7 +99,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is actually a dialog, hence, paragraph, not a list!.",
@@ -107,7 +107,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is actually a dialog, hence, paragraph, not a list!.",
@@ -115,7 +115,7 @@
               "icon": null,
               "content_lines": 57,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -128,7 +128,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -136,7 +136,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -144,7 +144,7 @@
               "icon": null,
               "content_lines": 73,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -157,7 +157,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is actually a dialog, hence, paragraph, not a list?!!!.",
@@ -165,7 +165,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is actually a dialog, hence, paragraph, not a list?!!!.",
@@ -173,7 +173,7 @@
               "icon": null,
               "content_lines": 60,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -186,7 +186,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -194,7 +194,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -202,7 +202,7 @@
               "icon": null,
               "content_lines": 73,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -215,7 +215,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is actually a dialog, hence, paragraph, not a list!...",
@@ -223,7 +223,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is actually a dialog, hence, paragraph, not a list!...",
@@ -231,7 +231,7 @@
               "icon": null,
               "content_lines": 59,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -244,7 +244,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -252,7 +252,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Because it ended in a period after the end-punctuation mark {{paragraph}}",
@@ -260,7 +260,7 @@
               "icon": null,
               "content_lines": 73,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/paragraph/complex/paragraph-multi-line.3viz.json
+++ b/test-docs/elements/paragraph/complex/paragraph-multi-line.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is a paragraph that has line breaks.We want to ensure this document has only one paragraphThis is the same paragraph {{paragraph}}",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a paragraph that has line breaks.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a paragraph that has line breaks.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 41,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "We want to ensure this document has only one paragraph",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 54,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -58,7 +58,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the same paragraph {{paragraph}}",
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 40,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/paragraph/complex/paragraph-single-line-lislike.3viz.json
+++ b/test-docs/elements/paragraph/complex/paragraph-single-line-lislike.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Since lines can never be a single item, they should always be a pargraph. All elements in this file should be {{paragraph}}",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Since lines can never be a single item, they should always be a pargraph. All elements in this file should be {{paragraph}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Since lines can never be a single item, they should always be a pargraph. All elements in this file should be {{paragraph}}",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 123,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": false,
         "style": "unordered"
       },
@@ -52,7 +52,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "-"
           },
           "children": [
@@ -62,7 +62,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -73,7 +73,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -83,7 +83,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/paragraph/paragraph-basic.3viz.json
+++ b/test-docs/elements/paragraph/paragraph-basic.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is a simple paragraph {{paragraph}}",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a simple paragraph {{paragraph}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a simple paragraph {{paragraph}}",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 40,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-ambiguous-cases.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-ambiguous-cases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Ambiguous Cases",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Ambiguous Cases",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Ambiguous Cases",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-extreme-cases.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-extreme-cases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Extreme Cases",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Extreme Cases",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Extreme Cases",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 13,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-invalid-bad.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-invalid-bad.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Invalid Parameter Syntax, the file is called bad so we can be ok with failure to parse",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Invalid Parameter Syntax, the file is called bad so we can be ok with failure to parse",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Invalid Parameter Syntax, the file is called bad so we can be ok with failure to parse",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 86,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-multiline.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-multiline.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Multi-line Annotation Edge Cases",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Multi-line Annotation Edge Cases",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Multi-line Annotation Edge Cases",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 32,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": ":: multiline:param=value :: This starts a multiline",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: multiline:param=value :: This starts a multiline",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 51,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    But parameters should only be on first line",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    But parameters should only be on first line",
@@ -84,7 +84,7 @@
                   "icon": null,
                   "content_lines": 47,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    :: nested:key=val :: This is content, not parameters",
@@ -103,7 +103,7 @@
                   "icon": null,
                   "content_lines": 56,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -118,7 +118,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": ":: another:key=\"multiline",
@@ -126,7 +126,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: another:key=\"multiline",
@@ -134,7 +134,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -145,7 +145,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    value\" :: Quoted value with newline (should it work?)",
@@ -153,7 +153,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    value\" :: Quoted value with newline (should it work?)",
@@ -161,7 +161,7 @@
                   "icon": null,
                   "content_lines": 57,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]

--- a/test-docs/elements/parameters/complex/parameters-namespace-edge-cases.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-namespace-edge-cases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Namespace Edge Cases",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Namespace Edge Cases",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Namespace Edge Cases",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-quoting.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-quoting.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Complex Quoting Scenarios",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Complex Quoting Scenarios",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Complex Quoting Scenarios",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 25,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-value-edge-cases.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-value-edge-cases.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Parameter Value Edge Cases",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Parameter Value Edge Cases",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Parameter Value Edge Cases",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 26,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-whitespace.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-whitespace.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Whitespace Handling",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Whitespace Handling",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Whitespace Handling",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 19,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": ":: spaced : key = value , other = \"with spaces\" :: Spaces around delimiters",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: spaced : key = value , other = \"with spaces\" :: Spaces around delimiters",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 75,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "::padded:    key=value    :: Extra whitespace in parameters",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 59,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -87,7 +87,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": ":: label:key=value trailing text :: Parameters with trailing content",
@@ -95,7 +95,7 @@
               "icon": null,
               "content_lines": 68,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/complex/parameters-with-annotation-values.3viz.json
+++ b/test-docs/elements/parameters/complex/parameters-with-annotation-values.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Interaction with Annotation Values",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Interaction with Annotation Values",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Interaction with Annotation Values",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 34,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/parameters/parameters-simple.3viz.json
+++ b/test-docs/elements/parameters/parameters-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Since parameters need an element to be in, this file will contain annotation elements with parameters.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Since parameters need an element to be in, this file will contain annotation elements with parameters.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Since parameters need an element to be in, this file will contain annotation elements with parameters.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 102,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/references/references-simple.3viz.json
+++ b/test-docs/elements/references/references-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 5,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Each paragraph has a reference by type.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Each paragraph has a reference by type.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Each paragraph has a reference by type.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 39,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 11,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is the url [WhatRefTarget(type='whatRefTarget', position=None, data={}, raw_content='http:://example.com/ref', icon='⁇')] reference, and the protocol is not required.",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the url ",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 16,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -75,7 +75,7 @@
               "icon": null,
               "content_lines": 45,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -86,7 +86,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "These are citactions references: ",
@@ -94,7 +94,7 @@
               "icon": null,
               "content_lines": 33,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -105,7 +105,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Author ",
@@ -113,7 +113,7 @@
               "icon": null,
               "content_lines": 7,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -122,7 +122,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -133,7 +133,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Authors ",
@@ -141,7 +141,7 @@
               "icon": null,
               "content_lines": 8,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -150,7 +150,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -161,7 +161,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Author + Page ",
@@ -169,7 +169,7 @@
               "icon": null,
               "content_lines": 14,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -178,7 +178,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -189,7 +189,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Author + Pages ",
@@ -197,7 +197,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -206,7 +206,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -217,7 +217,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Author + Page Interval ",
@@ -225,7 +225,7 @@
               "icon": null,
               "content_lines": 23,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -234,7 +234,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -245,7 +245,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the session ",
@@ -253,7 +253,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -262,7 +262,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -271,7 +271,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -282,7 +282,7 @@
           "icon": null,
           "content_lines": 13,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the page referenct ",
@@ -290,7 +290,7 @@
               "icon": null,
               "content_lines": 27,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -299,7 +299,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -308,7 +308,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -317,7 +317,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -326,7 +326,7 @@
               "icon": null,
               "content_lines": 18,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -335,7 +335,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -344,7 +344,7 @@
               "icon": null,
               "content_lines": 27,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -353,7 +353,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -362,7 +362,7 @@
               "icon": null,
               "content_lines": 22,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -371,7 +371,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -380,7 +380,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -389,7 +389,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -398,7 +398,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -409,7 +409,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the footnote ",
@@ -417,7 +417,7 @@
               "icon": null,
               "content_lines": 21,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -426,7 +426,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -435,7 +435,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -446,7 +446,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the path ",
@@ -454,7 +454,7 @@
               "icon": null,
               "content_lines": 17,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -463,7 +463,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -472,7 +472,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -485,7 +485,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is the TK (to come)[TkRefTarget(type='tkRefTarget', position=None, data={}, raw_content='TK', icon='⋯')] reference , and it signals some content will be inserted (lowecase should be valid too)",
@@ -493,7 +493,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is the TK (to come)",
@@ -501,7 +501,7 @@
               "icon": null,
               "content_lines": 24,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -510,7 +510,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -519,7 +519,7 @@
               "icon": null,
               "content_lines": 88,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -532,7 +532,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "The parser should make an effort to validate the reference type, but nor error or warn. To be a vlalid reference all it's needed is at least one alpha numberical character. And it should not do further validation such as validate paths or even sessions or footnotes in this same document.",
@@ -540,7 +540,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The parser should make an effort to validate the reference type, but nor error or warn. To be a vlalid reference all it's needed is at least one alpha numberical character. And it should not do further validation such as validate paths or even sessions or footnotes in this same document.",
@@ -548,7 +548,7 @@
               "icon": null,
               "content_lines": 288,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -561,7 +561,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "The precedence order is as it appears in this document,  and if none match, we use a defaut \"something\" (that is it's name) reference.",
@@ -569,7 +569,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The precedence order is as it appears in this document,  and if none match, we use a defaut \"something\" (that is it's name) reference.",
@@ -577,7 +577,7 @@
               "icon": null,
               "content_lines": 134,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/sessions/session-ancestors.3viz.json
+++ b/test-docs/elements/sessions/session-ancestors.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Deep Session {{session}}",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Content paragraph {{paragraph}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Content paragraph {{paragraph}}",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Content paragraph {{paragraph}}",
@@ -36,7 +36,7 @@
                   "icon": null,
                   "content_lines": 35,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        Nested paragraph {{paragraph, _ancestors=}}",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Nested paragraph {{paragraph, _ancestors=[WhatRefTarget(type='whatRefTarget', position=None, data={}, raw_content='session, session', icon='⁇')]}}",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 3,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Nested paragraph {{paragraph, _ancestors=",
@@ -73,7 +73,7 @@
                       "icon": null,
                       "content_lines": 49,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -82,7 +82,7 @@
                       "icon": null,
                       "content_lines": 0,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -91,7 +91,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/elements/sessions/session-basic.3viz.json
+++ b/test-docs/elements/sessions/session-basic.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Section Title {{session}}",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Content in section {{paragraph.textLine, _parent=paragraph}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Content in section {{paragraph.textLine, _parent=paragraph}}",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Content in section {{paragraph.textLine, _parent=paragraph}}",
@@ -36,7 +36,7 @@
                   "icon": null,
                   "content_lines": 64,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Another paragraph {{paragraph, _parent=session}}",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Another paragraph {{paragraph, _parent=session}}",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 52,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -80,7 +80,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "And now we wil test the session wihtouth markers",
@@ -88,7 +88,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "And now we wil test the session wihtouth markers",
@@ -96,7 +96,7 @@
               "icon": null,
               "content_lines": 48,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -109,7 +109,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Session Another (session}})",
@@ -117,7 +117,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Session Another (session}})",
@@ -125,7 +125,7 @@
               "icon": null,
               "content_lines": 27,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/verbatim/complex/verbatim-no-parsing.3viz.json
+++ b/test-docs/elements/verbatim/complex/verbatim-no-parsing.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "  This has *asterisks* and _underscores_\n  But they are `not` parsed as #formatting#",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Verbatim with formatting",
         "label": "",
         "parameters": {},
@@ -26,7 +26,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "The above verbatim block should preserve all formatting markers literally.",
@@ -34,7 +34,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The above verbatim block should preserve all formatting markers literally.",
@@ -42,7 +42,7 @@
               "icon": null,
               "content_lines": 74,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]

--- a/test-docs/elements/verbatim/complex/verbatim_parameters.3viz.json
+++ b/test-docs/elements/verbatim/complex/verbatim_parameters.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 7,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "    print(\"Hello, World!\")",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Simple parameter example",
         "label": "python",
         "parameters": {
@@ -28,7 +28,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Multiple parameters example",
         "label": "yaml",
         "parameters": {
@@ -45,7 +45,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Parameters with spaces in values",
         "label": "xml",
         "parameters": {
@@ -63,7 +63,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Label without parameters",
         "label": "sql",
         "parameters": {},
@@ -77,7 +77,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Empty label with parameters",
         "label": "",
         "parameters": {
@@ -94,7 +94,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Complex label with parameters",
         "label": "Debug Info",
         "parameters": {
@@ -111,7 +111,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "Edge case - single character keys (treated as math)",
         "label": "equation: a=1,b=2",
         "parameters": {},

--- a/test-docs/elements/verbatim/verbatim-simple.3viz.json
+++ b/test-docs/elements/verbatim/verbatim-simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 1,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Bogus session",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 12,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    in order to test a streched verbatim, we will include all the content in a session.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    in order to test a streched verbatim, we will include all the content in a session.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    in order to test a streched verbatim, we will include all the content in a session.",
@@ -36,7 +36,7 @@
                   "icon": null,
                   "content_lines": 87,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Basic verbatim examples (paragraph)",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Basic verbatim examples (paragraph)",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 39,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Simple verbatim with title and label",
             "label": "python",
             "parameters": {},
@@ -92,7 +92,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Anonymous verbatim (no title or label)",
@@ -100,7 +100,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Anonymous verbatim (no title or label)",
@@ -108,7 +108,7 @@
                   "icon": null,
                   "content_lines": 42,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -121,7 +121,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "",
             "label": "",
             "parameters": {},
@@ -135,7 +135,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Title only",
             "label": "",
             "parameters": {},
@@ -149,7 +149,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Label only. ",
@@ -157,7 +157,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Label only. ",
@@ -165,7 +165,7 @@
                   "icon": null,
                   "content_lines": 16,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -178,7 +178,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "",
             "label": "sql",
             "parameters": {},
@@ -192,7 +192,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "",
             "label": "",
             "parameters": {},
@@ -206,7 +206,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "First block",
             "label": "",
             "parameters": {},
@@ -220,7 +220,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Second block",
             "label": "",
             "parameters": {},
@@ -234,7 +234,7 @@
           "icon": null,
           "content_lines": 4,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Strecthed verbatim",
             "label": "",
             "parameters": {},

--- a/test-docs/ensambles/simple.3viz.json
+++ b/test-docs/ensambles/simple.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is a simple paragraph with no verbatim blocks.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a simple paragraph with no verbatim blocks.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a simple paragraph with no verbatim blocks.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 51,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Content of section one.",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Content of section one.",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Content of section one.",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 27,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -89,7 +89,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -99,7 +99,7 @@
                   "icon": null,
                   "content_lines": 17,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -110,7 +110,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -120,7 +120,7 @@
                   "icon": null,
                   "content_lines": 17,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -135,7 +135,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    More content here.",
@@ -143,7 +143,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    More content here.",
@@ -151,7 +151,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    More content here.",
@@ -159,7 +159,7 @@
                   "icon": null,
                   "content_lines": 22,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -172,7 +172,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Code example",
             "label": "python",
             "parameters": {},
@@ -186,7 +186,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    That's all!",
@@ -194,7 +194,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    That's all!",
@@ -202,7 +202,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]

--- a/test-docs/ensambles/tour.3viz.json
+++ b/test-docs/ensambles/tour.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 4,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Welcome to txxt! (paragraph, _path=\"document/paragraph\")",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Welcome to txxt! (paragraph, _path=\"document/paragraph\")",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Welcome to txxt! (paragraph, _path=\"document/paragraph\")",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 56,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This document is a brief tour of the txxt format, designed to get you started quickly. For a deeper dive, please refer to the detailed specification documents. (paragraph)",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This document is a brief tour of the txxt format, designed to get you started quickly. For a deeper dive, please refer to the detailed specification documents. (paragraph)",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 171,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    txxt is structured around sessions (like sections) and indentation. (paragraph, _path=\"document/session/paragraph\")",
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    txxt is structured around sessions (like sections) and indentation. (paragraph, _path=\"document/session/paragraph\")",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    txxt is structured around sessions (like sections) and indentation. (paragraph, _path=\"document/session/paragraph\")",
@@ -94,7 +94,7 @@
                   "icon": null,
                   "content_lines": 119,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -107,7 +107,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        And this is its content, indented one level. (paragraph, _path=\"document/session/session/paragraph\")",
@@ -115,7 +115,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        And this is its content, indented one level. (paragraph, _path=\"document/session/session/paragraph\")",
@@ -123,7 +123,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        And this is its content, indented one level. (paragraph, _path=\"document/session/session/paragraph\")",
@@ -131,7 +131,7 @@
                       "icon": null,
                       "content_lines": 108,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -148,7 +148,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "1. Lists (session, _path=\"document/session/session\")",
@@ -156,7 +156,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "List",
@@ -164,7 +164,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -175,7 +175,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -185,7 +185,7 @@
                       "icon": null,
                       "content_lines": 101,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -196,7 +196,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "1."
                   },
                   "children": [
@@ -206,7 +206,7 @@
                       "icon": null,
                       "content_lines": 61,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -215,7 +215,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 9
                       },
                       "children": [
@@ -225,7 +225,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "ordered": true,
                             "style": "ordered-numeric"
                           },
@@ -236,7 +236,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "1."
                               },
                               "children": [
@@ -246,7 +246,7 @@
                                   "icon": null,
                                   "content_lines": 99,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -267,7 +267,7 @@
           "icon": null,
           "content_lines": 8,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        For code or other pre-formatted text. (paragraph)",
@@ -275,7 +275,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        For code or other pre-formatted text. (paragraph)",
@@ -283,7 +283,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        For code or other pre-formatted text. (paragraph)",
@@ -291,7 +291,7 @@
                       "icon": null,
                       "content_lines": 57,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -304,7 +304,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "A simple code block",
                 "label": "",
                 "parameters": {},
@@ -318,7 +318,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        javascript(verbatim, label=\"javascript\", title=\"A simple code block\"):",
@@ -326,7 +326,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        javascript(verbatim, label=\"javascript\", title=\"A simple code block\"):",
@@ -334,7 +334,7 @@
                       "icon": null,
                       "content_lines": 78,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -347,7 +347,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        But you can go wild:",
@@ -355,7 +355,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        But you can go wild:",
@@ -363,7 +363,7 @@
                       "icon": null,
                       "content_lines": 28,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -374,7 +374,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            The universe tend towards maxium irony,  don't push it.",
@@ -382,7 +382,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            The universe tend towards maxium irony,  don't push it.",
@@ -390,7 +390,7 @@
                           "icon": null,
                           "content_lines": 67,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -405,7 +405,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        jwz(verbatim, label=\"jwz\", title=\"But you can go wild\"):",
@@ -413,7 +413,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        jwz(verbatim, label=\"jwz\", title=\"But you can go wild\"):",
@@ -421,7 +421,7 @@
                       "icon": null,
                       "content_lines": 64,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -434,7 +434,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Using it for citations, notes and other needs. The general form is: (paragraph)",
@@ -442,7 +442,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Using it for citations, notes and other needs. The general form is: (paragraph)",
@@ -450,7 +450,7 @@
                       "icon": null,
                       "content_lines": 87,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -463,7 +463,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "<optional title>",
                 "label": "",
                 "parameters": {},
@@ -477,7 +477,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        <optoinal lang label> (verbatim, title=\"<optional title>\", label=\"<optoinal lang label>\"):",
@@ -485,7 +485,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        <optoinal lang label> (verbatim, title=\"<optional title>\", label=\"<optoinal lang label>\"):",
@@ -493,7 +493,7 @@
                       "icon": null,
                       "content_lines": 98,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -508,7 +508,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        You can also reference images, videos, or audio. (paragraph)",
@@ -516,7 +516,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        You can also reference images, videos, or audio. (paragraph)",
@@ -524,7 +524,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        You can also reference images, videos, or audio. (paragraph)",
@@ -532,7 +532,7 @@
                       "icon": null,
                       "content_lines": 68,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -545,7 +545,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        A beautiful landscape:",
@@ -553,7 +553,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        A beautiful landscape:",
@@ -561,7 +561,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -572,7 +572,7 @@
                   "icon": null,
                   "content_lines": 5,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        image:src=",
@@ -580,7 +580,7 @@
                       "icon": null,
                       "content_lines": 18,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -589,7 +589,7 @@
                       "icon": null,
                       "content_lines": 0,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -598,7 +598,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -607,7 +607,7 @@
                       "icon": null,
                       "content_lines": 0,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -616,7 +616,7 @@
                       "icon": null,
                       "content_lines": 33,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -631,7 +631,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        Define terms clearly with the definition syntax. (paragraph)",
@@ -639,7 +639,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Define terms clearly with the definition syntax. (paragraph)",
@@ -647,7 +647,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Define terms clearly with the definition syntax. (paragraph)",
@@ -655,7 +655,7 @@
                       "icon": null,
                       "content_lines": 68,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -668,7 +668,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Term :: (definition, term=\"Term\", _path=\"document/session/session/definition\")",
@@ -676,7 +676,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Term :: (definition, term=\"Term\", _path=\"document/session/session/definition\")",
@@ -684,7 +684,7 @@
                       "icon": null,
                       "content_lines": 86,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -695,7 +695,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            The explanation or definition of the term goes here. (paragraph)",
@@ -703,7 +703,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            The explanation or definition of the term goes here. (paragraph)",
@@ -711,7 +711,7 @@
                           "icon": null,
                           "content_lines": 76,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -726,7 +726,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Parser :: (definition, term=\"Parser\")",
@@ -734,7 +734,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Parser :: (definition, term=\"Parser\")",
@@ -742,7 +742,7 @@
                       "icon": null,
                       "content_lines": 45,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -753,7 +753,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            A program that analyzes text according to formal grammar rules. (paragraph)",
@@ -761,7 +761,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            A program that analyzes text according to formal grammar rules. (paragraph)",
@@ -769,7 +769,7 @@
                           "icon": null,
                           "content_lines": 87,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]

--- a/test-docs/escaping/test_escaping.3viz.json
+++ b/test-docs/escaping/test_escaping.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 9,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This document tests all escape sequences in txxt.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This document tests all escape sequences in txxt.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This document tests all escape sequences in txxt.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 49,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Testing escaped inline markers:",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Testing escaped inline markers:",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Testing escaped inline markers:",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 35,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 8,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -89,7 +89,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -99,7 +99,7 @@
                   "icon": null,
                   "content_lines": 35,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -110,7 +110,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -120,7 +120,7 @@
                   "icon": null,
                   "content_lines": 39,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -131,7 +131,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -141,7 +141,7 @@
                   "icon": null,
                   "content_lines": 35,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -152,7 +152,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -162,7 +162,7 @@
                   "icon": null,
                   "content_lines": 28,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -171,7 +171,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "real italic",
@@ -179,7 +179,7 @@
                       "icon": null,
                       "content_lines": 11,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -190,7 +190,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -201,7 +201,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -211,7 +211,7 @@
                   "icon": null,
                   "content_lines": 30,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -222,7 +222,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -232,7 +232,7 @@
                   "icon": null,
                   "content_lines": 28,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -243,7 +243,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -253,7 +253,7 @@
                   "icon": null,
                   "content_lines": 22,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -262,7 +262,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "this should show backslash and asterisk",
@@ -270,7 +270,7 @@
                       "icon": null,
                       "content_lines": 39,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -283,7 +283,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -293,7 +293,7 @@
                   "icon": null,
                   "content_lines": 64,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -306,7 +306,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Edge cases:",
@@ -314,7 +314,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Edge cases:",
@@ -322,7 +322,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -337,7 +337,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Not a reference: not a link    Mixed: escaped but     Partial escapes: open only and close only",
@@ -345,7 +345,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Not a reference: not a link",
@@ -353,7 +353,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Not a reference: not a link",
@@ -361,7 +361,7 @@
                   "icon": null,
                   "content_lines": 33,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -372,7 +372,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Mixed: escaped but ",
@@ -380,7 +380,7 @@
                   "icon": null,
                   "content_lines": 25,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -389,7 +389,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -400,7 +400,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Partial escapes: open only and close only",
@@ -408,7 +408,7 @@
                   "icon": null,
                   "content_lines": 47,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -423,7 +423,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "1 Colon at End of Line",
@@ -431,7 +431,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        This line does not start a verbatim block        This one does:",
@@ -439,7 +439,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        This line does not start a verbatim block",
@@ -447,7 +447,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        This line does not start a verbatim block",
@@ -455,7 +455,7 @@
                       "icon": null,
                       "content_lines": 50,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -466,7 +466,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        This one does:",
@@ -474,7 +474,7 @@
                       "icon": null,
                       "content_lines": 22,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -485,7 +485,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            verbatim content here",
@@ -493,7 +493,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            verbatim content here",
@@ -501,7 +501,7 @@
                           "icon": null,
                           "content_lines": 33,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -516,7 +516,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        (python)",
@@ -524,7 +524,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        (python)",
@@ -532,7 +532,7 @@
                       "icon": null,
                       "content_lines": 16,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -547,7 +547,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        : not a annotation ::        : also not :: a annotation        :: real_annotation :: This is a real annotation",
@@ -555,7 +555,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        : not a annotation ::",
@@ -563,7 +563,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        : not a annotation ::",
@@ -571,7 +571,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -582,7 +582,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        : also not :: a annotation",
@@ -590,7 +590,7 @@
                       "icon": null,
                       "content_lines": 35,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -601,7 +601,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        :: real_annotation :: This is a real annotation",
@@ -609,7 +609,7 @@
                       "icon": null,
                       "content_lines": 55,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -624,7 +624,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "         This is not a list item         Neither is this        But these are real list items:",
@@ -632,7 +632,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "         This is not a list item",
@@ -640,7 +640,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "         This is not a list item",
@@ -648,7 +648,7 @@
                       "icon": null,
                       "content_lines": 33,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -659,7 +659,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "         Neither is this",
@@ -667,7 +667,7 @@
                       "icon": null,
                       "content_lines": 25,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -678,7 +678,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        But these are real list items:",
@@ -686,7 +686,7 @@
                       "icon": null,
                       "content_lines": 38,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -699,7 +699,7 @@
               "icon": null,
               "content_lines": 4,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -710,7 +710,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -720,7 +720,7 @@
                       "icon": null,
                       "content_lines": 21,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -731,7 +731,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -741,7 +741,7 @@
                       "icon": null,
                       "content_lines": 21,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -752,7 +752,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "1."
                   },
                   "children": [
@@ -762,7 +762,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -773,7 +773,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "1."
                   },
                   "children": [
@@ -783,7 +783,7 @@
                       "icon": null,
                       "content_lines": 22,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -796,7 +796,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Numbered lists:",
@@ -804,7 +804,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Numbered lists:",
@@ -812,7 +812,7 @@
                       "icon": null,
                       "content_lines": 23,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -829,7 +829,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Testing comma in parameters:    media:src=,alt=\"A wide shot with clouds\":",
@@ -837,7 +837,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Testing comma in parameters:",
@@ -845,7 +845,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Testing comma in parameters:",
@@ -853,7 +853,7 @@
                   "icon": null,
                   "content_lines": 32,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -864,7 +864,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    media:src=",
@@ -872,7 +872,7 @@
                   "icon": null,
                   "content_lines": 14,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -881,7 +881,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -890,7 +890,7 @@
                   "icon": null,
                   "content_lines": 32,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -903,7 +903,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Testing equals in parameters:",
@@ -911,7 +911,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Testing equals in parameters:",
@@ -919,7 +919,7 @@
                   "icon": null,
                   "content_lines": 33,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -930,7 +930,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    code:lang=python,equation=\"ab+c\":",
@@ -938,7 +938,7 @@
                   "icon": null,
                   "content_lines": 38,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -949,7 +949,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "def calculate(a, b, c)",
                 "label": "",
                 "parameters": {},
@@ -965,7 +965,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    (python)",
@@ -973,7 +973,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    (python)",
@@ -981,7 +981,7 @@
                   "icon": null,
                   "content_lines": 12,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -996,7 +996,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Literal backslash:     Multiple:  (should show two backslashes)    Before normal char: a (should show just 'a')    Windows path: C:UsersDocumentsfile.txt",
@@ -1004,7 +1004,7 @@
           "icon": null,
           "content_lines": 4,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Literal backslash: ",
@@ -1012,7 +1012,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Literal backslash: ",
@@ -1020,7 +1020,7 @@
                   "icon": null,
                   "content_lines": 24,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1031,7 +1031,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Multiple:  (should show two backslashes)",
@@ -1039,7 +1039,7 @@
                   "icon": null,
                   "content_lines": 46,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1050,7 +1050,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Before normal char: a (should show just 'a')",
@@ -1058,7 +1058,7 @@
                   "icon": null,
                   "content_lines": 48,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1069,7 +1069,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Windows path: C:UsersDocumentsfile.txt",
@@ -1077,7 +1077,7 @@
                   "icon": null,
                   "content_lines": 45,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1092,7 +1092,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "",
@@ -1100,7 +1100,7 @@
           "icon": null,
           "content_lines": 0,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Code with escapes",
             "label": "python",
             "parameters": {
@@ -1117,7 +1117,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    (python)",
@@ -1125,7 +1125,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    (python)",
@@ -1133,7 +1133,7 @@
                   "icon": null,
                   "content_lines": 12,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1146,7 +1146,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Dialog with escaped ending",
@@ -1154,7 +1154,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Dialog with escaped ending",
@@ -1162,7 +1162,7 @@
                   "icon": null,
                   "content_lines": 31,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1175,7 +1175,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -1186,7 +1186,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -1196,7 +1196,7 @@
                   "icon": null,
                   "content_lines": 19,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1207,7 +1207,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -1217,7 +1217,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1232,7 +1232,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    These should just remove the backslash:",
@@ -1240,7 +1240,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    These should just remove the backslash:",
@@ -1248,7 +1248,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    These should just remove the backslash:",
@@ -1256,7 +1256,7 @@
                   "icon": null,
                   "content_lines": 43,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1269,7 +1269,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -1280,7 +1280,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -1290,7 +1290,7 @@
                   "icon": null,
                   "content_lines": 17,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1301,7 +1301,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -1311,7 +1311,7 @@
                   "icon": null,
                   "content_lines": 17,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1322,7 +1322,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -1332,7 +1332,7 @@
                   "icon": null,
                   "content_lines": 17,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1347,7 +1347,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Escaped Unicode: u00A9 (should show u00A9, not ©)    Tab normalization still works:    This has a real tab    But escaped tab: t (should show 't')",
@@ -1355,7 +1355,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Escaped Unicode: u00A9 (should show u00A9, not ©)",
@@ -1363,7 +1363,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Escaped Unicode: u00A9 (should show u00A9, not ©)",
@@ -1371,7 +1371,7 @@
                   "icon": null,
                   "content_lines": 53,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1382,7 +1382,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Tab normalization still works:    This has a real tab",
@@ -1390,7 +1390,7 @@
                   "icon": null,
                   "content_lines": 57,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1401,7 +1401,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    But escaped tab: t (should show 't')",
@@ -1409,7 +1409,7 @@
                   "icon": null,
                   "content_lines": 40,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]

--- a/test-docs/escaping/test_simple_escaping.3viz.json
+++ b/test-docs/escaping/test_simple_escaping.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 2,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "Basic Escaping",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    This tests escaped asterisks and escaped underscores.    Also escaped backticks and escaped brackets.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    This tests escaped asterisks and escaped underscores.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This tests escaped asterisks and escaped underscores.",
@@ -36,7 +36,7 @@
                   "icon": null,
                   "content_lines": 61,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Also escaped backticks and escaped brackets.",
@@ -55,7 +55,7 @@
                   "icon": null,
                   "content_lines": 52,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -70,7 +70,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Normal  and  and .    But escaped not bold and not italic.",
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Normal bold and italic and code.",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 7,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Normal ",
@@ -94,7 +94,7 @@
                   "icon": null,
                   "content_lines": 11,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -103,7 +103,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "bold",
@@ -111,7 +111,7 @@
                       "icon": null,
                       "content_lines": 4,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -122,7 +122,7 @@
                   "icon": null,
                   "content_lines": 5,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -131,7 +131,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "italic",
@@ -139,7 +139,7 @@
                       "icon": null,
                       "content_lines": 6,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -150,7 +150,7 @@
                   "icon": null,
                   "content_lines": 5,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -159,7 +159,7 @@
                   "icon": null,
                   "content_lines": 4,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -168,7 +168,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -179,7 +179,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    But escaped not bold and not italic.",
@@ -187,7 +187,7 @@
                   "icon": null,
                   "content_lines": 44,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]

--- a/test-docs/specs/micro.3viz.json
+++ b/test-docs/specs/micro.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 11,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is a paragraph:This documenent is the micro spec, showing all elemetns, but not covering their full variations.This will not cover all permutations, but cover all variations.  Aside from parsing ambiguities this does excercises the full synstax swath",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a paragraph:",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a paragraph:",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This documenent is the micro spec, showing all elemetns, but not covering their full variations.",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 96,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -58,7 +58,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This will not cover all permutations, but cover all variations.  Aside from parsing ambiguities this does excercises the full synstax swath",
@@ -66,7 +66,7 @@
               "icon": null,
               "content_lines": 139,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -79,7 +79,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -90,7 +90,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -100,7 +100,7 @@
               "icon": null,
               "content_lines": 11,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -109,7 +109,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -119,7 +119,7 @@
                   "icon": null,
                   "content_lines": 4,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "    :: status ::  status-style=RFC :: ",
@@ -127,7 +127,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "    :: status ::  status-style=RFC :: ",
@@ -135,7 +135,7 @@
                           "icon": null,
                           "content_lines": 38,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -146,7 +146,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        Proposal. ",
@@ -154,7 +154,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Proposal. ",
@@ -162,7 +162,7 @@
                               "icon": null,
                               "content_lines": 18,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -175,7 +175,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        Annotations can be multi-line for longer notes, and also support, live verbatim, parameters.",
@@ -183,7 +183,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        Annotations can be multi-line for longer notes, and also support, live verbatim, parameters.",
@@ -191,7 +191,7 @@
                               "icon": null,
                               "content_lines": 100,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -202,7 +202,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "        They support the whole txxt lang , excetp new sessions of course. And this goodie is not unique to annotations.",
@@ -210,7 +210,7 @@
                               "icon": null,
                               "content_lines": 119,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -223,7 +223,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "ordered": false,
                         "style": "unordered"
                       },
@@ -234,7 +234,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "marker": "-"
                           },
                           "children": [
@@ -244,7 +244,7 @@
                               "icon": null,
                               "content_lines": 109,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -255,7 +255,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "marker": "-"
                           },
                           "children": [
@@ -265,7 +265,7 @@
                               "icon": null,
                               "content_lines": 134,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -286,7 +286,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Core Elements {{session}}",
@@ -294,7 +294,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        Which should have at least one item.",
@@ -302,7 +302,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Which should have at least one item.",
@@ -310,7 +310,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Which should have at least one item.",
@@ -318,7 +318,7 @@
                       "icon": null,
                       "content_lines": 44,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -333,7 +333,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        But every session has to have something in it",
@@ -341,7 +341,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        But every session has to have something in it",
@@ -349,7 +349,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        But every session has to have something in it",
@@ -357,7 +357,7 @@
                       "icon": null,
                       "content_lines": 53,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -374,7 +374,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "List",
@@ -382,7 +382,7 @@
           "icon": null,
           "content_lines": 5,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -393,7 +393,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -403,7 +403,7 @@
                   "icon": null,
                   "content_lines": 51,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -414,7 +414,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -424,7 +424,7 @@
                   "icon": null,
                   "content_lines": 42,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -435,7 +435,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -445,7 +445,7 @@
                   "icon": null,
                   "content_lines": 58,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -456,7 +456,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "1."
               },
               "children": [
@@ -466,7 +466,7 @@
                   "icon": null,
                   "content_lines": 46,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -477,7 +477,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "2."
               },
               "children": [
@@ -487,7 +487,7 @@
                   "icon": null,
                   "content_lines": 47,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -496,7 +496,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "indent": 5
                   },
                   "children": [
@@ -506,7 +506,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "ordered": false,
                         "style": "unordered"
                       },
@@ -517,7 +517,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "marker": "a)"
                           },
                           "children": [
@@ -527,7 +527,7 @@
                               "icon": null,
                               "content_lines": 35,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -538,7 +538,7 @@
                           "icon": null,
                           "content_lines": 2,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "marker": "b)"
                           },
                           "children": [
@@ -548,7 +548,7 @@
                               "icon": null,
                               "content_lines": 39,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             },
                             {
@@ -557,7 +557,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "indent": 9
                               },
                               "children": [
@@ -567,7 +567,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {
+                                  "extra": {
                                     "ordered": true,
                                     "style": "ordered-alpha"
                                   },
@@ -578,7 +578,7 @@
                                       "icon": null,
                                       "content_lines": 1,
                                       "source_location": null,
-                                      "metadata": {
+                                      "extra": {
                                         "marker": "i."
                                       },
                                       "children": [
@@ -588,7 +588,7 @@
                                           "icon": null,
                                           "content_lines": 54,
                                           "source_location": null,
-                                          "metadata": {},
+                                          "extra": {},
                                           "children": []
                                         }
                                       ]
@@ -607,7 +607,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "Content",
@@ -615,7 +615,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "indent": 9
                           },
                           "children": [
@@ -625,7 +625,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "            A list who is part of a list litem, it's parent's.",
@@ -633,7 +633,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "            A list who is part of a list litem, it's parent's.",
@@ -641,7 +641,7 @@
                                       "icon": null,
                                       "content_lines": 62,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -666,7 +666,7 @@
       "icon": null,
       "content_lines": 14,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "4. Verbatim",
         "label": "",
         "parameters": {},
@@ -680,7 +680,7 @@
       "icon": null,
       "content_lines": 5,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "| Name | Age | ",
@@ -688,7 +688,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "| Name | Age | ",
@@ -696,7 +696,7 @@
               "icon": null,
               "content_lines": 15,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -707,7 +707,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "|---------|----|",
@@ -715,7 +715,7 @@
               "icon": null,
               "content_lines": 16,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -726,7 +726,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "| Jen | 24 |",
@@ -734,7 +734,7 @@
               "icon": null,
               "content_lines": 12,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -745,7 +745,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "| Bob | 20 |",
@@ -753,7 +753,7 @@
               "icon": null,
               "content_lines": 12,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -764,7 +764,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    (markdown table)",
@@ -772,7 +772,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    (markdown table)",
@@ -780,7 +780,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -795,7 +795,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "            Not mandatory, but the block content is taken to represent the media, could be used as alt.",
@@ -803,7 +803,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "A beautiful landscape",
             "label": "image",
             "parameters": {
@@ -820,7 +820,7 @@
           "icon": null,
           "content_lines": 0,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "The Greattes",
             "label": "video src=https",
             "parameters": {
@@ -836,7 +836,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": true,
             "style": "ordered-numeric"
           },
@@ -847,7 +847,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "6."
               },
               "children": [
@@ -857,7 +857,7 @@
                   "icon": null,
                   "content_lines": 18,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -866,7 +866,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "indent": 5
                   },
                   "children": [
@@ -876,7 +876,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "Content",
@@ -884,7 +884,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "indent": 9
                           },
                           "children": [
@@ -894,7 +894,7 @@
                               "icon": null,
                               "content_lines": 2,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "            The explanation or definition of the term goes here. It can span ",
@@ -902,7 +902,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "            The explanation or definition of the term goes here. It can span ",
@@ -910,7 +910,7 @@
                                       "icon": null,
                                       "content_lines": 77,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -921,7 +921,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "            multiple lines and contain any txxt content.",
@@ -929,7 +929,7 @@
                                       "icon": null,
                                       "content_lines": 56,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -954,7 +954,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Inlines are formats whiting a body of text:  asterisks for  ,  underscores for  ,  backticks for  , Math is supported:  , citations:  or with pages  ",
@@ -962,7 +962,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Inlines are formats whiting a body of text:  asterisks for bold ,  underscores for italic ,  backticks for monospace , Math is supported:  , citations:  or with pages  ",
@@ -970,7 +970,7 @@
               "icon": null,
               "content_lines": 13,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Inlines are formats whiting a body of text:  asterisks for ",
@@ -978,7 +978,7 @@
                   "icon": null,
                   "content_lines": 63,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -987,7 +987,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "bold",
@@ -995,7 +995,7 @@
                       "icon": null,
                       "content_lines": 4,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1006,7 +1006,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1015,7 +1015,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "italic",
@@ -1023,7 +1023,7 @@
                       "icon": null,
                       "content_lines": 6,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1034,7 +1034,7 @@
                   "icon": null,
                   "content_lines": 18,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1043,7 +1043,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1052,7 +1052,7 @@
                   "icon": null,
                   "content_lines": 22,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1061,7 +1061,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1070,7 +1070,7 @@
                   "icon": null,
                   "content_lines": 14,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1079,7 +1079,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1088,7 +1088,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1097,7 +1097,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1106,7 +1106,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1121,7 +1121,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -1132,7 +1132,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "8."
           },
           "children": [
@@ -1142,7 +1142,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -1151,7 +1151,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -1161,7 +1161,7 @@
                   "icon": null,
                   "content_lines": 7,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -1172,7 +1172,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1182,7 +1182,7 @@
                           "icon": null,
                           "content_lines": 37,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1191,7 +1191,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1200,7 +1200,7 @@
                           "icon": null,
                           "content_lines": 15,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1211,7 +1211,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1221,7 +1221,7 @@
                           "icon": null,
                           "content_lines": 25,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1230,7 +1230,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1239,7 +1239,7 @@
                           "icon": null,
                           "content_lines": 15,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1250,7 +1250,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1260,7 +1260,7 @@
                           "icon": null,
                           "content_lines": 32,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1269,7 +1269,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1278,7 +1278,7 @@
                           "icon": null,
                           "content_lines": 15,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1289,7 +1289,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1299,7 +1299,7 @@
                           "icon": null,
                           "content_lines": 18,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1308,7 +1308,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1317,7 +1317,7 @@
                           "icon": null,
                           "content_lines": 30,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1328,7 +1328,7 @@
                       "icon": null,
                       "content_lines": 6,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1338,7 +1338,7 @@
                           "icon": null,
                           "content_lines": 14,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1347,7 +1347,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1356,7 +1356,7 @@
                           "icon": null,
                           "content_lines": 10,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1365,7 +1365,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1374,7 +1374,7 @@
                           "icon": null,
                           "content_lines": 25,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1383,7 +1383,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1394,7 +1394,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1404,7 +1404,7 @@
                           "icon": null,
                           "content_lines": 25,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1413,7 +1413,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1422,7 +1422,7 @@
                           "icon": null,
                           "content_lines": 40,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1433,7 +1433,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -1443,7 +1443,7 @@
                           "icon": null,
                           "content_lines": 21,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -1452,7 +1452,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1471,7 +1471,7 @@
       "icon": null,
       "content_lines": 8,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Can be single lined. {{paragraph}}",
@@ -1479,7 +1479,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Can be single lined. {{paragraph}}",
@@ -1487,7 +1487,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Can be single lined. {{paragraph}}",
@@ -1495,7 +1495,7 @@
                   "icon": null,
                   "content_lines": 38,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1508,7 +1508,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Can be single line but. Multi sentence. {{paragraph}}",
@@ -1516,7 +1516,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Can be single line but. Multi sentence. {{paragraph}}",
@@ -1524,7 +1524,7 @@
                   "icon": null,
                   "content_lines": 57,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1537,7 +1537,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Can be multiline. ",
@@ -1545,7 +1545,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Can be multiline. ",
@@ -1553,7 +1553,7 @@
                   "icon": null,
                   "content_lines": 22,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1564,7 +1564,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Like this, many times the result of hard wrapping editors {{pargraph}}",
@@ -1572,7 +1572,7 @@
                   "icon": null,
                   "content_lines": 74,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1585,7 +1585,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Dialog could look exactly like a list. To force the parser to treat this as a dialog, add and aditional period after the firts's line end-punctuation, as in: ",
@@ -1593,7 +1593,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Dialog could look exactly like a list. To force the parser to treat this as a dialog, add and aditional period after the firts's line end-punctuation, as in: ",
@@ -1601,7 +1601,7 @@
                   "icon": null,
                   "content_lines": 162,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1614,7 +1614,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    - Ma, this is not alist , but a dialog!.",
@@ -1622,7 +1622,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    - Ma, this is not alist , but a dialog!.",
@@ -1630,7 +1630,7 @@
                   "icon": null,
                   "content_lines": 44,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1643,7 +1643,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    - Yup kiddo, I see it. Because the first line added a \".\" after the end-punctuation {{!}}",
@@ -1651,7 +1651,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    - Yup kiddo, I see it. Because the first line added a \".\" after the end-punctuation {{!}}",
@@ -1659,7 +1659,7 @@
                   "icon": null,
                   "content_lines": 93,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1672,7 +1672,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    - That's right Ma and this is true for  any end-punctuatio ( ?., !., !!., ??., ....)",
@@ -1680,7 +1680,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    - That's right Ma and this is true for  any end-punctuatio ( ?., !., !!., ??., ....)",
@@ -1688,7 +1688,7 @@
                   "icon": null,
                   "content_lines": 88,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1701,7 +1701,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    - Well said, son, oh, and you only need to mark the first line. {{paragraph}}",
@@ -1709,7 +1709,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    - Well said, son, oh, and you only need to mark the first line. {{paragraph}}",
@@ -1717,7 +1717,7 @@
                   "icon": null,
                   "content_lines": 81,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1732,7 +1732,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    1. This is that first footnote.",
@@ -1740,7 +1740,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    1. This is that first footnote.",
@@ -1748,7 +1748,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    1. This is that first footnote.",
@@ -1756,7 +1756,7 @@
                   "icon": null,
                   "content_lines": 35,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1769,7 +1769,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    You can reference sessions by their numbers, and session 0 is taken to be the last one in the document.",
@@ -1777,7 +1777,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    You can reference sessions by their numbers, and session 0 is taken to be the last one in the document.",
@@ -1785,7 +1785,7 @@
                   "icon": null,
                   "content_lines": 107,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1796,7 +1796,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    If you don't use a # for the number, it's taken to mean 0, hence the last one.",
@@ -1804,7 +1804,7 @@
                   "icon": null,
                   "content_lines": 82,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1815,7 +1815,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Then in this case, this item is ",
@@ -1823,7 +1823,7 @@
                   "icon": null,
                   "content_lines": 36,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1832,7 +1832,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1841,7 +1841,7 @@
                   "icon": null,
                   "content_lines": 52,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1850,7 +1850,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -1859,7 +1859,7 @@
                   "icon": null,
                   "content_lines": 6,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]

--- a/test-docs/specs/nano.3viz.json
+++ b/test-docs/specs/nano.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 7,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This is a paragraph: {{paragraph}}This documenent is the nanos spec, showing all elemetns, but not covering their full variations.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This is a paragraph: {{paragraph}}",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This is a paragraph: {{paragraph}}",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 34,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This documenent is the nanos spec, showing all elemetns, but not covering their full variations.",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 96,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -60,7 +60,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -71,7 +71,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "1."
           },
           "children": [
@@ -81,7 +81,7 @@
               "icon": null,
               "content_lines": 20,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -90,7 +90,7 @@
               "icon": null,
               "content_lines": 0,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": []
@@ -103,7 +103,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "2."
           },
           "children": [
@@ -113,7 +113,7 @@
               "icon": null,
               "content_lines": 30,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -122,7 +122,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -132,7 +132,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": true,
                     "style": "ordered-numeric"
                   },
@@ -143,7 +143,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "2."
                       },
                       "children": [
@@ -153,7 +153,7 @@
                           "icon": null,
                           "content_lines": 42,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -162,7 +162,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "indent": 5
                           },
                           "children": [
@@ -172,7 +172,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "        Which should have at least one item.",
@@ -180,7 +180,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "        Which should have at least one item.",
@@ -188,7 +188,7 @@
                                       "icon": null,
                                       "content_lines": 44,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -213,7 +213,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -224,7 +224,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "3."
           },
           "children": [
@@ -234,7 +234,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -243,7 +243,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -253,7 +253,7 @@
                   "icon": null,
                   "content_lines": 3,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -264,7 +264,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -274,7 +274,7 @@
                           "icon": null,
                           "content_lines": 50,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -285,7 +285,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "1."
                       },
                       "children": [
@@ -295,7 +295,7 @@
                           "icon": null,
                           "content_lines": 58,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -306,7 +306,7 @@
                       "icon": null,
                       "content_lines": 2,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "2."
                       },
                       "children": [
@@ -316,7 +316,7 @@
                           "icon": null,
                           "content_lines": 60,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -325,7 +325,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "indent": 5
                           },
                           "children": [
@@ -335,7 +335,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "ordered": true,
                                 "style": "ordered-numeric"
                               },
@@ -346,7 +346,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {
+                                  "extra": {
                                     "marker": "1."
                                   },
                                   "children": [
@@ -356,7 +356,7 @@
                                       "icon": null,
                                       "content_lines": 34,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -381,7 +381,7 @@
       "icon": null,
       "content_lines": 12,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "title": "4. Verbatim",
         "label": "",
         "parameters": {},
@@ -395,7 +395,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "        A beautiful landscape:        (image: src=, alt=\"Mountain vista\") {{verbatim}}",
@@ -403,7 +403,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        A beautiful landscape:",
@@ -411,7 +411,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        A beautiful landscape:",
@@ -419,7 +419,7 @@
                   "icon": null,
                   "content_lines": 30,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -430,7 +430,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        (image: src=",
@@ -438,7 +438,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -447,7 +447,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -456,7 +456,7 @@
                   "icon": null,
                   "content_lines": 36,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -469,7 +469,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        Term :: {{definition}}",
@@ -477,7 +477,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Term :: {{definition}}",
@@ -485,7 +485,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Term :: {{definition}}",
@@ -493,7 +493,7 @@
                       "icon": null,
                       "content_lines": 30,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -504,7 +504,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            The explanation or definition of the term goes here. It can span ",
@@ -512,7 +512,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            The explanation or definition of the term goes here. It can span ",
@@ -520,7 +520,7 @@
                           "icon": null,
                           "content_lines": 77,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -531,7 +531,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            multiple lines and contain any txxt content.",
@@ -539,7 +539,7 @@
                           "icon": null,
                           "content_lines": 56,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -558,7 +558,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Inlines are formats whiting a body of text:  asterisks for  {{strong}} ,  underscores for  {{emphasis}} ,  backticks for  {{code}} , Math is supported:  {{math}} , citations:  or with pages  ",
@@ -566,7 +566,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Inlines are formats whiting a body of text:  asterisks for bold {{strong}} ,  underscores for italic {{emphasis}} ,  backticks for monospace {{code}} , Math is supported:  {{math}} , citations:  or with pages  ",
@@ -574,7 +574,7 @@
               "icon": null,
               "content_lines": 13,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Inlines are formats whiting a body of text:  asterisks for ",
@@ -582,7 +582,7 @@
                   "icon": null,
                   "content_lines": 63,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -591,7 +591,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "bold",
@@ -599,7 +599,7 @@
                       "icon": null,
                       "content_lines": 4,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -610,7 +610,7 @@
                   "icon": null,
                   "content_lines": 31,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -619,7 +619,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "italic",
@@ -627,7 +627,7 @@
                       "icon": null,
                       "content_lines": 6,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -638,7 +638,7 @@
                   "icon": null,
                   "content_lines": 31,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -647,7 +647,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -656,7 +656,7 @@
                   "icon": null,
                   "content_lines": 31,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -665,7 +665,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -674,7 +674,7 @@
                   "icon": null,
                   "content_lines": 23,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -683,7 +683,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -692,7 +692,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -701,7 +701,7 @@
                   "icon": null,
                   "content_lines": 0,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -710,7 +710,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -725,7 +725,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {
+      "extra": {
         "ordered": true,
         "style": "ordered-numeric"
       },
@@ -736,7 +736,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "marker": "8."
           },
           "children": [
@@ -746,7 +746,7 @@
               "icon": null,
               "content_lines": 10,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             },
             {
@@ -755,7 +755,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 1
               },
               "children": [
@@ -765,7 +765,7 @@
                   "icon": null,
                   "content_lines": 5,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "ordered": false,
                     "style": "unordered"
                   },
@@ -776,7 +776,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -786,7 +786,7 @@
                           "icon": null,
                           "content_lines": 37,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -795,7 +795,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -804,7 +804,7 @@
                           "icon": null,
                           "content_lines": 14,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -815,7 +815,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -825,7 +825,7 @@
                           "icon": null,
                           "content_lines": 25,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -834,7 +834,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -843,7 +843,7 @@
                           "icon": null,
                           "content_lines": 14,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -854,7 +854,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -864,7 +864,7 @@
                           "icon": null,
                           "content_lines": 32,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -873,7 +873,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -882,7 +882,7 @@
                           "icon": null,
                           "content_lines": 14,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -893,7 +893,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -903,7 +903,7 @@
                           "icon": null,
                           "content_lines": 18,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -912,7 +912,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -921,7 +921,7 @@
                           "icon": null,
                           "content_lines": 29,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -932,7 +932,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "marker": "-"
                       },
                       "children": [
@@ -942,7 +942,7 @@
                           "icon": null,
                           "content_lines": 25,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -951,7 +951,7 @@
                           "icon": null,
                           "content_lines": 0,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         },
                         {
@@ -960,7 +960,7 @@
                           "icon": null,
                           "content_lines": 39,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]

--- a/test-docs/structure/session-structure.3viz.json
+++ b/test-docs/structure/session-structure.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 7,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "The most complex part of txxt to parse is the structure being derived from the indentation.The indentation itself is not the problem, but the lack of explicit syntax for most elements is, which generates various ambiguities.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "The most complex part of txxt to parse is the structure being derived from the indentation.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The most complex part of txxt to parse is the structure being derived from the indentation.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 91,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -39,7 +39,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "The indentation itself is not the problem, but the lack of explicit syntax for most elements is, which generates various ambiguities.",
@@ -47,7 +47,7 @@
               "icon": null,
               "content_lines": 133,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -60,7 +60,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This document aggregates most of these issues, both for reference and tests. Do not add cases to it.",
@@ -68,7 +68,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This document aggregates most of these issues, both for reference and tests. Do not add cases to it.",
@@ -76,7 +76,7 @@
               "icon": null,
               "content_lines": 100,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -89,7 +89,7 @@
       "icon": null,
       "content_lines": 3,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    There are three elements that cannot be identified by themselves, that is, by only looking at the line they are in. These are: ",
@@ -97,7 +97,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    There are three elements that cannot be identified by themselves, that is, by only looking at the line they are in. These are: ",
@@ -105,7 +105,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    There are three elements that cannot be identified by themselves, that is, by only looking at the line they are in. These are: ",
@@ -113,7 +113,7 @@
                   "icon": null,
                   "content_lines": 131,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -126,7 +126,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -137,7 +137,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -147,7 +147,7 @@
                   "icon": null,
                   "content_lines": 37,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -158,7 +158,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -168,7 +168,7 @@
                   "icon": null,
                   "content_lines": 16,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -179,7 +179,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -189,7 +189,7 @@
                   "icon": null,
                   "content_lines": 16,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -202,7 +202,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    All these can have similar forms. While list items do require a list marker (- or 1.), session titles and paragraphs do not and can contain them. Hence, for some variants you can write list items off these three as consistently intertwined. ",
@@ -210,7 +210,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    All these can have similar forms. While list items do require a list marker (- or 1.), session titles and paragraphs do not and can contain them. Hence, for some variants you can write list items off these three as consistently intertwined. ",
@@ -218,7 +218,7 @@
                   "icon": null,
                   "content_lines": 245,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -233,7 +233,7 @@
       "icon": null,
       "content_lines": 2,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    The general idea is that sessions create a new , deeper level, thus +1 indented.     Like here, the \"2. General Idea\" line itself could be any one of the three. How do you tell them apart?     The key is that session and lists require other features in the text, if you can't find them, by exclusion the element will be the paragraph.",
@@ -241,7 +241,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    The general idea is that sessions create a new , deeper level, thus +1 indented. ",
@@ -249,7 +249,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    The general idea is that sessions create a new , deeper level, thus +1 indented. ",
@@ -257,7 +257,7 @@
                   "icon": null,
                   "content_lines": 85,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -268,7 +268,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Like here, the \"2. General Idea\" line itself could be any one of the three. How do you tell them apart? ",
@@ -276,7 +276,7 @@
                   "icon": null,
                   "content_lines": 108,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -287,7 +287,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    The key is that session and lists require other features in the text, if you can't find them, by exclusion the element will be the paragraph.",
@@ -295,7 +295,7 @@
                   "icon": null,
                   "content_lines": 145,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -308,7 +308,7 @@
           "icon": null,
           "content_lines": 6,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "            Foo \n\n            Bar",
@@ -316,7 +316,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "A session's title has to be preceded by a blank line, it's content is +1 Indented and Sessions cannot be empty. Hence",
                 "label": "txxt",
                 "parameters": {},
@@ -330,7 +330,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Foo and Bar can only be paragraphs.",
@@ -338,7 +338,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Foo and Bar can only be paragraphs.",
@@ -346,7 +346,7 @@
                       "icon": null,
                       "content_lines": 43,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -359,7 +359,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Any valid session child would be +1 indented. ",
@@ -367,7 +367,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Any valid session child would be +1 indented. ",
@@ -375,7 +375,7 @@
                       "icon": null,
                       "content_lines": 54,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -388,7 +388,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "title": "Here is the edge Case",
                 "label": "txxt",
                 "parameters": {},
@@ -402,7 +402,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        What is each element in this example?  The way to decide is this: ",
@@ -410,7 +410,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        What is each element in this example?  The way to decide is this: ",
@@ -418,7 +418,7 @@
                       "icon": null,
                       "content_lines": 74,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -431,7 +431,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -442,7 +442,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -452,7 +452,7 @@
                       "icon": null,
                       "content_lines": 111,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -463,7 +463,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -473,7 +473,7 @@
                       "icon": null,
                       "content_lines": 38,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -484,7 +484,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -494,7 +494,7 @@
                       "icon": null,
                       "content_lines": 285,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -511,7 +511,7 @@
       "icon": null,
       "content_lines": 7,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Note that in the example above we don't consider c. Foo to be a possible list. That is because lists cannot contain only one element (nesting included, that is, child-lists's items do count as one). So: ",
@@ -519,7 +519,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Note that in the example above we don't consider c. Foo to be a possible list. That is because lists cannot contain only one element (nesting included, that is, child-lists's items do count as one). So: ",
@@ -527,7 +527,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Note that in the example above we don't consider c. Foo to be a possible list. That is because lists cannot contain only one element (nesting included, that is, child-lists's items do count as one). So: ",
@@ -535,7 +535,7 @@
                   "icon": null,
                   "content_lines": 207,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -548,7 +548,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -559,7 +559,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -569,7 +569,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -580,7 +580,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -590,7 +590,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -601,7 +601,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -611,7 +611,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -620,7 +620,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "indent": 5
                   },
                   "children": [
@@ -630,7 +630,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "ordered": true,
                         "style": "ordered-numeric"
                       },
@@ -641,7 +641,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "marker": "1."
                           },
                           "children": [
@@ -651,7 +651,7 @@
                               "icon": null,
                               "content_lines": 14,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -670,7 +670,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Is a list, so it",
@@ -678,7 +678,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Is a list, so it",
@@ -686,7 +686,7 @@
                   "icon": null,
                   "content_lines": 20,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -699,7 +699,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Because, including nested lists, we have 2 items here.",
@@ -707,7 +707,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Because, including nested lists, we have 2 items here.",
@@ -715,7 +715,7 @@
                   "icon": null,
                   "content_lines": 58,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -728,7 +728,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Now,: ",
@@ -736,7 +736,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Now,: ",
@@ -744,7 +744,7 @@
                   "icon": null,
                   "content_lines": 10,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -757,7 +757,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -768,7 +768,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -778,7 +778,7 @@
                   "icon": null,
                   "content_lines": 9,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -791,7 +791,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Is not a list, is a paragraph, as lists cannot be single items.",
@@ -799,7 +799,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Is not a list, is a paragraph, as lists cannot be single items.",
@@ -807,7 +807,7 @@
                   "icon": null,
                   "content_lines": 67,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -818,7 +818,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    This fact, together with sessions requiring a preceding blank line, pretty much disambiguates all cases, but one.",
@@ -826,7 +826,7 @@
                   "icon": null,
                   "content_lines": 117,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -841,7 +841,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    While txxt is geared towards technical writing, it should be able to correctly represent dialogs, which, as one expects, uses the same initial characters as some lists, the dash. Hence:",
@@ -849,7 +849,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    While txxt is geared towards technical writing, it should be able to correctly represent dialogs, which, as one expects, uses the same initial characters as some lists, the dash. Hence:",
@@ -857,7 +857,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    While txxt is geared towards technical writing, it should be able to correctly represent dialogs, which, as one expects, uses the same initial characters as some lists, the dash. Hence:",
@@ -865,7 +865,7 @@
                   "icon": null,
                   "content_lines": 189,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -878,7 +878,7 @@
           "icon": null,
           "content_lines": 4,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -889,7 +889,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -899,7 +899,7 @@
                   "icon": null,
                   "content_lines": 26,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -910,7 +910,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -920,7 +920,7 @@
                   "icon": null,
                   "content_lines": 16,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -931,7 +931,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -941,7 +941,7 @@
                   "icon": null,
                   "content_lines": 27,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -952,7 +952,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -962,7 +962,7 @@
                   "icon": null,
                   "content_lines": 16,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -975,7 +975,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Could be a perfectly fine list, but in this example it's a dialog. ",
@@ -983,7 +983,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Could be a perfectly fine list, but in this example it's a dialog. ",
@@ -991,7 +991,7 @@
                   "icon": null,
                   "content_lines": 71,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1002,7 +1002,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    The way to tell txxt that such line is a paragraph is by adding a period to the end-punctuation",
@@ -1010,7 +1010,7 @@
                   "icon": null,
                   "content_lines": 99,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1023,7 +1023,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Here since the first line ends with \".\" and the preceding character is a valid end punctuation mark (?, ., !, .. and others) it's a dialog. Note that only the first line needs to have the extra period.",
@@ -1031,7 +1031,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Here since the first line ends with \".\" and the preceding character is a valid end punctuation mark (?, ., !, .. and others) it's a dialog. Note that only the first line needs to have the extra period.",
@@ -1039,7 +1039,7 @@
                   "icon": null,
                   "content_lines": 205,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1054,7 +1054,7 @@
       "icon": null,
       "content_lines": 14,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    As we've seen indentation always denotes the structure, the parent-child relationship, but it's not technically how this is implemented.",
@@ -1062,7 +1062,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    As we've seen indentation always denotes the structure, the parent-child relationship, but it's not technically how this is implemented.",
@@ -1070,7 +1070,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    As we've seen indentation always denotes the structure, the parent-child relationship, but it's not technically how this is implemented.",
@@ -1078,7 +1078,7 @@
                   "icon": null,
                   "content_lines": 140,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1091,7 +1091,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    As we've seen in both these: ",
@@ -1099,7 +1099,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    As we've seen in both these: ",
@@ -1107,7 +1107,7 @@
                   "icon": null,
                   "content_lines": 33,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1120,7 +1120,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        A paragraph, followed by a list",
@@ -1128,7 +1128,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        A paragraph, followed by a list",
@@ -1136,7 +1136,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        A paragraph, followed by a list",
@@ -1144,7 +1144,7 @@
                       "icon": null,
                       "content_lines": 39,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1157,7 +1157,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": true,
                 "style": "ordered-numeric"
               },
@@ -1168,7 +1168,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "1."
                   },
                   "children": [
@@ -1178,7 +1178,7 @@
                       "icon": null,
                       "content_lines": 24,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     },
                     {
@@ -1187,7 +1187,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {
+                      "extra": {
                         "indent": 9
                       },
                       "children": [
@@ -1197,7 +1197,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {
+                          "extra": {
                             "ordered": true,
                             "style": "ordered-numeric"
                           },
@@ -1208,7 +1208,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {
+                              "extra": {
                                 "marker": "1."
                               },
                               "children": [
@@ -1218,7 +1218,7 @@
                                   "icon": null,
                                   "content_lines": 23,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -1239,7 +1239,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    The title, and the outer list (pack for trip) are not indented +1, although they denote the relationship. The reason for this is containers. ",
@@ -1247,7 +1247,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    The title, and the outer list (pack for trip) are not indented +1, although they denote the relationship. The reason for this is containers. ",
@@ -1255,7 +1255,7 @@
                   "icon": null,
                   "content_lines": 145,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1268,7 +1268,7 @@
           "icon": null,
           "content_lines": 7,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Containers is how any element that can have children work. Their form is",
             "label": "txxt",
             "parameters": {},
@@ -1282,7 +1282,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    In this case lists look like this: ",
@@ -1290,7 +1290,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    In this case lists look like this: ",
@@ -1298,7 +1298,7 @@
                   "icon": null,
                   "content_lines": 39,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1311,7 +1311,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    <list-item>",
@@ -1319,7 +1319,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    <list-item>",
@@ -1327,7 +1327,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1338,7 +1338,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        <text line>",
@@ -1346,7 +1346,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        <text line>",
@@ -1354,7 +1354,7 @@
                       "icon": null,
                       "content_lines": 19,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1365,7 +1365,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        <container>",
@@ -1373,7 +1373,7 @@
                       "icon": null,
                       "content_lines": 19,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1384,7 +1384,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        </container>",
@@ -1392,7 +1392,7 @@
                       "icon": null,
                       "content_lines": 20,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1407,7 +1407,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    </list-item",
@@ -1415,7 +1415,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    </list-item",
@@ -1423,7 +1423,7 @@
                   "icon": null,
                   "content_lines": 15,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1436,7 +1436,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    If a list has no children the text line is aligned with the parent. When a nested list exists, then it will be like this: ",
@@ -1444,7 +1444,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    If a list has no children the text line is aligned with the parent. When a nested list exists, then it will be like this: ",
@@ -1452,7 +1452,7 @@
                   "icon": null,
                   "content_lines": 126,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1465,7 +1465,7 @@
           "icon": null,
           "content_lines": 3,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    <list>",
@@ -1473,7 +1473,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    <list>",
@@ -1481,7 +1481,7 @@
                   "icon": null,
                   "content_lines": 10,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1492,7 +1492,7 @@
               "icon": null,
               "content_lines": 3,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        <outter-list-item>",
@@ -1500,7 +1500,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        <outter-list-item>",
@@ -1508,7 +1508,7 @@
                       "icon": null,
                       "content_lines": 26,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1519,7 +1519,7 @@
                   "icon": null,
                   "content_lines": 4,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            <text-line>",
@@ -1527,7 +1527,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            <text-line>",
@@ -1535,7 +1535,7 @@
                           "icon": null,
                           "content_lines": 23,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1546,7 +1546,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            <container>",
@@ -1554,7 +1554,7 @@
                           "icon": null,
                           "content_lines": 23,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1565,7 +1565,7 @@
                       "icon": null,
                       "content_lines": 3,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "                <list>",
@@ -1573,7 +1573,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "                <list>",
@@ -1581,7 +1581,7 @@
                               "icon": null,
                               "content_lines": 22,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -1592,7 +1592,7 @@
                           "icon": null,
                           "content_lines": 2,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "                    <inner-list-item>",
@@ -1600,7 +1600,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "                    <inner-list-item>",
@@ -1608,7 +1608,7 @@
                                   "icon": null,
                                   "content_lines": 37,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -1619,7 +1619,7 @@
                               "icon": null,
                               "content_lines": 2,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "                        <text line>",
@@ -1627,7 +1627,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "                        <text line>",
@@ -1635,7 +1635,7 @@
                                       "icon": null,
                                       "content_lines": 35,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -1646,7 +1646,7 @@
                                   "icon": null,
                                   "content_lines": 1,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": [
                                     {
                                       "label": "                        </container>",
@@ -1654,7 +1654,7 @@
                                       "icon": null,
                                       "content_lines": 36,
                                       "source_location": null,
-                                      "metadata": {},
+                                      "extra": {},
                                       "children": []
                                     }
                                   ]
@@ -1669,7 +1669,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "                    </inner-list-item>",
@@ -1677,7 +1677,7 @@
                               "icon": null,
                               "content_lines": 1,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": [
                                 {
                                   "label": "                    </inner-list-item>",
@@ -1685,7 +1685,7 @@
                                   "icon": null,
                                   "content_lines": 38,
                                   "source_location": null,
-                                  "metadata": {},
+                                  "extra": {},
                                   "children": []
                                 }
                               ]
@@ -1700,7 +1700,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "                </list>",
@@ -1708,7 +1708,7 @@
                           "icon": null,
                           "content_lines": 1,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": [
                             {
                               "label": "                </list>",
@@ -1716,7 +1716,7 @@
                               "icon": null,
                               "content_lines": 23,
                               "source_location": null,
-                              "metadata": {},
+                              "extra": {},
                               "children": []
                             }
                           ]
@@ -1731,7 +1731,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "            </container>",
@@ -1739,7 +1739,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "            </container>",
@@ -1747,7 +1747,7 @@
                           "icon": null,
                           "content_lines": 24,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -1762,7 +1762,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        </outter-list-item>",
@@ -1770,7 +1770,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        </outter-list-item>",
@@ -1778,7 +1778,7 @@
                       "icon": null,
                       "content_lines": 27,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1793,7 +1793,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    </list>",
@@ -1801,7 +1801,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    </list>",
@@ -1809,7 +1809,7 @@
                   "icon": null,
                   "content_lines": 11,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1822,7 +1822,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    There are two types of containers: ContentContainers and Session Containers.",
@@ -1830,7 +1830,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    There are two types of containers: ContentContainers and Session Containers.",
@@ -1838,7 +1838,7 @@
                   "icon": null,
                   "content_lines": 80,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -1851,7 +1851,7 @@
           "icon": null,
           "content_lines": 4,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        The following elements have them, that is, they can have multiple children; ",
@@ -1859,7 +1859,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        The following elements have them, that is, they can have multiple children; ",
@@ -1867,7 +1867,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        The following elements have them, that is, they can have multiple children; ",
@@ -1875,7 +1875,7 @@
                       "icon": null,
                       "content_lines": 84,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1888,7 +1888,7 @@
               "icon": null,
               "content_lines": 5,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "ordered": false,
                 "style": "unordered"
               },
@@ -1899,7 +1899,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -1909,7 +1909,7 @@
                       "icon": null,
                       "content_lines": 21,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1920,7 +1920,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -1930,7 +1930,7 @@
                       "icon": null,
                       "content_lines": 21,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1941,7 +1941,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -1951,7 +1951,7 @@
                       "icon": null,
                       "content_lines": 15,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1962,7 +1962,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -1972,7 +1972,7 @@
                       "icon": null,
                       "content_lines": 40,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -1983,7 +1983,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {
+                  "extra": {
                     "marker": "-"
                   },
                   "children": [
@@ -1993,7 +1993,7 @@
                       "icon": null,
                       "content_lines": 99,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -2006,7 +2006,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        These elements cannot host children: ",
@@ -2014,7 +2014,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        These elements cannot host children: ",
@@ -2022,7 +2022,7 @@
                       "icon": null,
                       "content_lines": 45,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -2035,7 +2035,7 @@
               "icon": null,
               "content_lines": 2,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        Content containers can attach any element type but one Session. ",
@@ -2043,7 +2043,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        Content containers can attach any element type but one Session. ",
@@ -2051,7 +2051,7 @@
                       "icon": null,
                       "content_lines": 72,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -2062,7 +2062,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        It makes sense, right? You don't want an inner list item creating a new session, from a navigation point of view it would not make any sense, hence:",
@@ -2070,7 +2070,7 @@
                       "icon": null,
                       "content_lines": 156,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -2085,7 +2085,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "        These are and behave just like the Content ones, with the exception that they can hold another sessions. Hence the document's root is a session container of its own. ",
@@ -2093,7 +2093,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        These are and behave just like the Content ones, with the exception that they can hold another sessions. Hence the document's root is a session container of its own. ",
@@ -2101,7 +2101,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        These are and behave just like the Content ones, with the exception that they can hold another sessions. Hence the document's root is a session container of its own. ",
@@ -2109,7 +2109,7 @@
                       "icon": null,
                       "content_lines": 174,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -2122,7 +2122,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        ps: currently the implementation still has session as having a title attribute then children node not the container here described. This is temporary so we're documenting the correct information.",
@@ -2130,7 +2130,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        ps: currently the implementation still has session as having a title attribute then children node not the container here described. This is temporary so we're documenting the correct information.",
@@ -2138,7 +2138,7 @@
                       "icon": null,
                       "content_lines": 203,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]

--- a/test-docs/test-assertion-positions.3viz.json
+++ b/test-docs/test-assertion-positions.3viz.json
@@ -4,7 +4,7 @@
   "icon": null,
   "content_lines": 3,
   "source_location": null,
-  "metadata": {},
+  "extra": {},
   "children": [
     {
       "label": "This {{paragraph}} is a paragraph.",
@@ -12,7 +12,7 @@
       "icon": null,
       "content_lines": 1,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "This {{paragraph}} is a paragraph.",
@@ -20,7 +20,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "This {{paragraph}} is a paragraph.",
@@ -28,7 +28,7 @@
               "icon": null,
               "content_lines": 34,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": []
             }
           ]
@@ -41,7 +41,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "    Paragraphs {{paragraph}} have assertions at the start.",
@@ -49,7 +49,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Paragraphs {{paragraph}} have assertions at the start.",
@@ -57,7 +57,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Paragraphs {{paragraph}} have assertions at the start.",
@@ -65,7 +65,7 @@
                   "icon": null,
                   "content_lines": 58,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -78,7 +78,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Lists have assertions at item start:",
@@ -86,7 +86,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Lists have assertions at item start:",
@@ -94,7 +94,7 @@
                   "icon": null,
                   "content_lines": 40,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -107,7 +107,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "ordered": false,
             "style": "unordered"
           },
@@ -118,7 +118,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -128,7 +128,7 @@
                   "icon": null,
                   "content_lines": 29,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -139,7 +139,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "marker": "-"
               },
               "children": [
@@ -149,7 +149,7 @@
                   "icon": null,
                   "content_lines": 30,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -162,7 +162,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    Inline elements: {{strong}}bold, {{emphasis}}italic, {{code}}code",
@@ -170,7 +170,7 @@
               "icon": null,
               "content_lines": 6,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    Inline elements: ",
@@ -178,7 +178,7 @@
                   "icon": null,
                   "content_lines": 21,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -187,7 +187,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "{{strong}}bold",
@@ -195,7 +195,7 @@
                       "icon": null,
                       "content_lines": 14,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -206,7 +206,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -215,7 +215,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "{{emphasis}}italic",
@@ -223,7 +223,7 @@
                       "icon": null,
                       "content_lines": 18,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -234,7 +234,7 @@
                   "icon": null,
                   "content_lines": 2,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 },
                 {
@@ -243,7 +243,7 @@
                   "icon": null,
                   "content_lines": 12,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -258,7 +258,7 @@
       "icon": null,
       "content_lines": 4,
       "source_location": null,
-      "metadata": {},
+      "extra": {},
       "children": [
         {
           "label": "Definition",
@@ -266,7 +266,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "Content",
@@ -274,7 +274,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {
+              "extra": {
                 "indent": 5
               },
               "children": [
@@ -284,7 +284,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        The assertion goes in the term line.",
@@ -292,7 +292,7 @@
                       "icon": null,
                       "content_lines": 1,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": [
                         {
                           "label": "        The assertion goes in the term line.",
@@ -300,7 +300,7 @@
                           "icon": null,
                           "content_lines": 44,
                           "source_location": null,
-                          "metadata": {},
+                          "extra": {},
                           "children": []
                         }
                       ]
@@ -317,7 +317,7 @@
           "icon": null,
           "content_lines": 2,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    :: label {{annotation}} :: Value",
@@ -325,7 +325,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    :: label {{annotation}} :: Value",
@@ -333,7 +333,7 @@
                   "icon": null,
                   "content_lines": 36,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]
@@ -344,7 +344,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "        For annotations, current implementation expects assertion in value.",
@@ -352,7 +352,7 @@
                   "icon": null,
                   "content_lines": 1,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": [
                     {
                       "label": "        For annotations, current implementation expects assertion in value.",
@@ -360,7 +360,7 @@
                       "icon": null,
                       "content_lines": 75,
                       "source_location": null,
-                      "metadata": {},
+                      "extra": {},
                       "children": []
                     }
                   ]
@@ -375,7 +375,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {
+          "extra": {
             "title": "Code block title",
             "label": "",
             "parameters": {},
@@ -389,7 +389,7 @@
           "icon": null,
           "content_lines": 1,
           "source_location": null,
-          "metadata": {},
+          "extra": {},
           "children": [
             {
               "label": "    javascript: {{verbatim, label=\"javascript\"}}",
@@ -397,7 +397,7 @@
               "icon": null,
               "content_lines": 1,
               "source_location": null,
-              "metadata": {},
+              "extra": {},
               "children": [
                 {
                   "label": "    javascript: {{verbatim, label=\"javascript\"}}",
@@ -405,7 +405,7 @@
                   "icon": null,
                   "content_lines": 48,
                   "source_location": null,
-                  "metadata": {},
+                  "extra": {},
                   "children": []
                 }
               ]


### PR DESCRIPTION
Complete the refactor from Node.metadata to Node.extra to better reflect the purpose of storing additional user data in AST nodes.

Changes:
- Fix dataclass field() parameters: Use metadata= for Python field docs
- Update all test data files: Replace "metadata" with "extra" in JSON
- Maintain Python dataclass field.metadata for documentation
- All 262 tests pass after refactor

The Node.extra field now clearly represents additional data users may store in AST nodes that 3viz should display, distinct from Python's dataclass field metadata mechanism.

🤖 Generated with [Claude Code](https://claude.ai/code)