### PR TITLE
Add dynamic topic-based help system

### DIFF
--- a/docs/shell-help/3viz-output.md
+++ b/docs/shell-help/3viz-output.md
@@ -1,0 +1,59 @@
+# 3viz Output Format
+
+3viz provides multiple output formats to suit different use cases, from human-readable terminal output to machine-processable JSON.
+
+## Output Formats
+
+**term**: Terminal-friendly with icons and colors (default for terminals)
+- Uses Unicode icons for visual distinction
+- Automatic width detection
+- Color coding for different elements
+- Best for interactive exploration
+
+**text**: Plain text without special formatting (default for pipes)
+- ASCII-safe output
+- No Unicode icons or colors
+- Suitable for logs, emails, documentation
+- Consistent across all environments
+
+**json**: Machine-readable JSON structure
+- Complete data preservation
+- Easy to parse programmatically
+- Includes all metadata and source locations
+- Perfect for further processing
+
+**yaml**: Human-readable YAML format
+- Structured but readable
+- Good for configuration files
+- Preserves hierarchical relationships
+- Easy to edit manually
+
+## Understanding the Output
+
+Each line represents a node in the tree:
+
+```
+⧉ Document                                                     7L
+  ⊤ Heading: "Getting Started"                                 1L
+    ↵ Getting Started                                           1L
+  ¶ Paragraph                                                   2L
+    ↵ This is the first line of the paragraph.                 1L
+    ↵ This is the second line.                                 1L
+```
+
+**Structure**:
+- Indentation shows hierarchy
+- Icons indicate node types  
+- Labels show node content or type
+- Line counts (7L, 1L, 2L) show content size
+- Extra metadata appears after labels
+
+**Common Icons**:
+- ⧉ Document/Root
+- ⊤ Heading
+- ¶ Paragraph  
+- ↵ Text/Line
+- ☰ List
+- • List Item
+- 𝒱 Code Block
+- ƒ Inline Code

--- a/docs/shell-help/adapters.md
+++ b/docs/shell-help/adapters.md
@@ -1,0 +1,48 @@
+# Adapters
+
+Adapters are configuration files that tell 3viz how to interpret different AST formats. They provide a mapping between the source format and 3viz's internal representation.
+
+## How Adapters Work
+
+An adapter defines:
+- **Field mappings**: Which fields contain labels, types, children, etc.
+- **Icon mappings**: Visual icons for different node types
+- **Type overrides**: Special handling for specific node types
+- **Filtering**: Which node types to ignore during processing
+
+## Built-in Adapters
+
+**3viz**: The native format, no adaptation needed
+- Direct mapping to 3viz Node structure
+- Supports all 3viz features out of the box
+
+**mdast**: Markdown Abstract Syntax Tree
+- Maps markdown elements to visual representations
+- Handles headings, paragraphs, lists, code blocks, etc.
+- Icons: ⧉ (root), ⊤ (heading), ¶ (paragraph), 𝒱 (code)
+
+**unist**: Universal Syntax Tree
+- Generic adapter for Unist-based formats
+- Minimal mapping suitable for many tree formats
+
+## Custom Adapters
+
+Create JSON or YAML files with adapter definitions:
+
+```json
+{
+  "label": "name",
+  "type": "type", 
+  "children": "body",
+  "icons": {
+    "function": "ƒ",
+    "class": "⊙",
+    "variable": "𝑥"
+  }
+}
+```
+
+Save as `my-adapter.json` and use with:
+```bash
+3viz document.ast my-adapter.json
+```

--- a/docs/shell-help/examples.md
+++ b/docs/shell-help/examples.md
@@ -1,0 +1,52 @@
+# Examples
+
+Here are practical examples of using 3viz with different types of ASTs and scenarios.
+
+## Working with MDAST (Markdown)
+
+```bash
+# Basic markdown visualization
+echo '{"type": "root", "children": [{"type": "heading", "depth": 1, "children": [{"type": "text", "value": "Hello World"}]}]}' | 3viz - mdast
+
+# Output formats comparison
+3viz markdown.json mdast --output-format term
+3viz markdown.json mdast --output-format json  
+3viz markdown.json mdast --output-format yaml
+```
+
+## Custom Adapter Example
+
+Create a simple adapter for JavaScript ASTs:
+
+**js-adapter.json:**
+```json
+{
+  "label": "name",
+  "type": "type",
+  "children": "body", 
+  "icons": {
+    "Program": "📄",
+    "FunctionDeclaration": "ƒ",
+    "VariableDeclaration": "𝑥",
+    "BinaryExpression": "⊕",
+    "Identifier": "🏷"
+  }
+}
+```
+
+**Usage:**
+```bash
+3viz ast.json js-adapter.json --output-format term
+```
+
+## Pipeline Processing
+
+```bash
+# Extract function names from JavaScript AST
+3viz ast.json js-adapter.json --output-format json | \
+  jq -r '.. | select(.type? == "FunctionDeclaration") | .label'
+
+# Count node types
+3viz document.json --output-format json | \
+  jq -r '.. | .type? // empty' | sort | uniq -c
+```

--- a/docs/shell-help/getting-started.md
+++ b/docs/shell-help/getting-started.md
@@ -1,0 +1,41 @@
+# Getting Started with 3viz
+
+3viz is a command-line tool for visualizing Abstract Syntax Trees (ASTs) in a readable, hierarchical format.
+
+## Quick Start
+
+**Basic Usage:**
+```bash
+# Visualize a JSON AST with default adapter
+3viz document.json
+
+# Use a specific adapter  
+3viz document.json mdast
+
+# Read from stdin
+cat document.json | 3viz - mdast
+
+# Output in different formats
+3viz document.json --output-format yaml
+```
+
+**Common Workflows:**
+
+1. **Exploring a new AST format**: Start with the default 3viz adapter to see the raw structure
+2. **Using built-in adapters**: Try mdast for Markdown or unist for generic trees  
+3. **Creating custom adapters**: Define field mappings for your specific AST format
+4. **Processing output**: Use JSON/YAML formats for further analysis
+
+## What You'll See
+
+3viz shows your AST as an indented tree with:
+- Visual icons for different node types
+- Content size indicators (line counts)
+- Hierarchical structure through indentation
+- Node labels and metadata
+
+## Next Steps
+
+- `3viz help adapters` - Learn about adapters and format mapping
+- `3viz help 3viz-output` - Understand output formats and structure
+- `3viz get-definition mdast` - See adapter definitions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ urls = { "Homepage" = "https://github.com/arthur-debert/treeviz-py" }
 [tool.poetry]
 version = "0.0.1"
 packages = [{ include = "treeviz", from = "python/src" }]
-include = ["python/src/treeviz/**", "LICENSE", "README.txt"]
+include = ["docs/shell-help/*.md", "LICENSE", "README.txt"]
 exclude = ["tests"]
 
 [tool.poetry.scripts]

--- a/python/src/treeviz/__main__.py
+++ b/python/src/treeviz/__main__.py
@@ -182,6 +182,7 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] not in [
         "render",
         "get-definition",
+        "help",
         "--help",
         "--version",
     ]:

--- a/python/src/treeviz/cli.py
+++ b/python/src/treeviz/cli.py
@@ -6,10 +6,54 @@ Business logic is implemented in __main__.py.
 """
 
 import sys
+from pathlib import Path
 
 import click
 
 from .definitions import Lib
+
+
+def _get_help_dir() -> Path:
+    """Get the help directory, handling both development and installed scenarios."""
+    # Try development path first (relative to repo root)
+    dev_help_dir = (
+        Path(__file__).parent.parent.parent.parent / "docs" / "shell-help"
+    )
+    if dev_help_dir.exists():
+        return dev_help_dir
+
+    # For installed packages, use package data
+    pkg_help_dir = Path(__file__).parent / "data" / "shell-help"
+    if pkg_help_dir.exists():
+        return pkg_help_dir
+
+    # Last resort: return dev path even if it doesn't exist
+    return dev_help_dir
+
+
+def _load_help_topic(topic_name: str) -> str:
+    """Load help content from markdown file."""
+    help_dir = _get_help_dir()
+    help_file = help_dir / f"{topic_name}.md"
+
+    try:
+        return help_file.read_text()
+    except FileNotFoundError:
+        return f"Help topic '{topic_name}' not found."
+
+
+def _discover_help_topics() -> list:
+    """Discover available help topics from markdown files."""
+    help_dir = _get_help_dir()
+
+    if not help_dir.exists():
+        return []
+
+    topics = []
+    for md_file in help_dir.glob("*.md"):
+        topics.append(md_file.stem)
+
+    return sorted(topics)
 
 
 @click.group()
@@ -116,6 +160,89 @@ def get_definition(ctx, format_name):
 
     output_format = ctx.obj["output_format"]
     __main__.get_definition(format_name, output_format)
+
+
+class HelpGroup(click.Group):
+    """Custom help group that dynamically discovers help topics."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._dynamic_commands = {}
+        self._load_dynamic_commands()
+
+    def _load_dynamic_commands(self):
+        """Load help topics from markdown files."""
+        topics = _discover_help_topics()
+        for topic in topics:
+            # Create a dynamic command for each topic
+            def make_help_command(topic_name):
+                def help_command():
+                    content = _load_help_topic(topic_name)
+                    click.echo(content)
+
+                return help_command
+
+            # Set up the command
+            cmd = make_help_command(topic)
+            cmd.__name__ = topic.replace("-", "_")
+            cmd.__doc__ = f"Show help for {topic}"
+
+            # Convert to Click command
+            click_cmd = click.command(name=topic)(cmd)
+            self._dynamic_commands[topic] = click_cmd
+
+    def get_command(self, ctx, cmd_name):
+        # First try dynamic commands
+        if cmd_name in self._dynamic_commands:
+            return self._dynamic_commands[cmd_name]
+
+        # Fall back to regular commands
+        return super().get_command(ctx, cmd_name)
+
+    def list_commands(self, ctx):
+        # Only list regular commands in the Commands section
+        # Dynamic commands will be shown in Available Topics section
+        return super().list_commands(ctx)
+
+    def format_help(self, ctx, formatter):
+        """Override help formatting to show available topics."""
+        # Show the basic help first
+        super().format_help(ctx, formatter)
+
+        # Add available topics section
+        topics = _discover_help_topics()
+        if topics:
+            with formatter.section("Available Topics"):
+                formatter.write_paragraph()
+                for topic in topics:
+                    formatter.write_text(f"  3viz help {topic}")
+                formatter.write_paragraph()
+                formatter.write_text(
+                    "Topics are loaded from markdown files in docs/shell-help/"
+                )
+
+
+@cli.group(cls=HelpGroup)
+def help():
+    """Shows help for specific topics.
+
+    Help topics are loaded dynamically from markdown files in docs/shell-help/.
+    """
+    pass
+
+
+@help.command()
+def list():
+    """List all available help topics."""
+    topics = _discover_help_topics()
+    if topics:
+        click.echo("Available help topics:")
+        for topic in topics:
+            click.echo(f"  3viz help {topic}")
+    else:
+        click.echo("No help topics found.")
+
+    click.echo("\nTo add new topics, create markdown files in docs/shell-help/")
 
 
 if __name__ == "__main__":

--- a/python/src/treeviz/data/__init__.py
+++ b/python/src/treeviz/data/__init__.py
@@ -1,0 +1,1 @@
+# Package data module

--- a/python/src/treeviz/data/shell-help/3viz-output.md
+++ b/python/src/treeviz/data/shell-help/3viz-output.md
@@ -1,0 +1,59 @@
+# 3viz Output Format
+
+3viz provides multiple output formats to suit different use cases, from human-readable terminal output to machine-processable JSON.
+
+## Output Formats
+
+**term**: Terminal-friendly with icons and colors (default for terminals)
+- Uses Unicode icons for visual distinction
+- Automatic width detection
+- Color coding for different elements
+- Best for interactive exploration
+
+**text**: Plain text without special formatting (default for pipes)
+- ASCII-safe output
+- No Unicode icons or colors
+- Suitable for logs, emails, documentation
+- Consistent across all environments
+
+**json**: Machine-readable JSON structure
+- Complete data preservation
+- Easy to parse programmatically
+- Includes all metadata and source locations
+- Perfect for further processing
+
+**yaml**: Human-readable YAML format
+- Structured but readable
+- Good for configuration files
+- Preserves hierarchical relationships
+- Easy to edit manually
+
+## Understanding the Output
+
+Each line represents a node in the tree:
+
+```
+⧉ Document                                                     7L
+  ⊤ Heading: "Getting Started"                                 1L
+    ↵ Getting Started                                           1L
+  ¶ Paragraph                                                   2L
+    ↵ This is the first line of the paragraph.                 1L
+    ↵ This is the second line.                                 1L
+```
+
+**Structure**:
+- Indentation shows hierarchy
+- Icons indicate node types  
+- Labels show node content or type
+- Line counts (7L, 1L, 2L) show content size
+- Extra metadata appears after labels
+
+**Common Icons**:
+- ⧉ Document/Root
+- ⊤ Heading
+- ¶ Paragraph  
+- ↵ Text/Line
+- ☰ List
+- • List Item
+- 𝒱 Code Block
+- ƒ Inline Code

--- a/python/src/treeviz/data/shell-help/adapters.md
+++ b/python/src/treeviz/data/shell-help/adapters.md
@@ -1,0 +1,48 @@
+# Adapters
+
+Adapters are configuration files that tell 3viz how to interpret different AST formats. They provide a mapping between the source format and 3viz's internal representation.
+
+## How Adapters Work
+
+An adapter defines:
+- **Field mappings**: Which fields contain labels, types, children, etc.
+- **Icon mappings**: Visual icons for different node types
+- **Type overrides**: Special handling for specific node types
+- **Filtering**: Which node types to ignore during processing
+
+## Built-in Adapters
+
+**3viz**: The native format, no adaptation needed
+- Direct mapping to 3viz Node structure
+- Supports all 3viz features out of the box
+
+**mdast**: Markdown Abstract Syntax Tree
+- Maps markdown elements to visual representations
+- Handles headings, paragraphs, lists, code blocks, etc.
+- Icons: ⧉ (root), ⊤ (heading), ¶ (paragraph), 𝒱 (code)
+
+**unist**: Universal Syntax Tree
+- Generic adapter for Unist-based formats
+- Minimal mapping suitable for many tree formats
+
+## Custom Adapters
+
+Create JSON or YAML files with adapter definitions:
+
+```json
+{
+  "label": "name",
+  "type": "type", 
+  "children": "body",
+  "icons": {
+    "function": "ƒ",
+    "class": "⊙",
+    "variable": "𝑥"
+  }
+}
+```
+
+Save as `my-adapter.json` and use with:
+```bash
+3viz document.ast my-adapter.json
+```

--- a/python/src/treeviz/data/shell-help/examples.md
+++ b/python/src/treeviz/data/shell-help/examples.md
@@ -1,0 +1,52 @@
+# Examples
+
+Here are practical examples of using 3viz with different types of ASTs and scenarios.
+
+## Working with MDAST (Markdown)
+
+```bash
+# Basic markdown visualization
+echo '{"type": "root", "children": [{"type": "heading", "depth": 1, "children": [{"type": "text", "value": "Hello World"}]}]}' | 3viz - mdast
+
+# Output formats comparison
+3viz markdown.json mdast --output-format term
+3viz markdown.json mdast --output-format json  
+3viz markdown.json mdast --output-format yaml
+```
+
+## Custom Adapter Example
+
+Create a simple adapter for JavaScript ASTs:
+
+**js-adapter.json:**
+```json
+{
+  "label": "name",
+  "type": "type",
+  "children": "body", 
+  "icons": {
+    "Program": "📄",
+    "FunctionDeclaration": "ƒ",
+    "VariableDeclaration": "𝑥",
+    "BinaryExpression": "⊕",
+    "Identifier": "🏷"
+  }
+}
+```
+
+**Usage:**
+```bash
+3viz ast.json js-adapter.json --output-format term
+```
+
+## Pipeline Processing
+
+```bash
+# Extract function names from JavaScript AST
+3viz ast.json js-adapter.json --output-format json | \
+  jq -r '.. | select(.type? == "FunctionDeclaration") | .label'
+
+# Count node types
+3viz document.json --output-format json | \
+  jq -r '.. | .type? // empty' | sort | uniq -c
+```

--- a/python/src/treeviz/data/shell-help/getting-started.md
+++ b/python/src/treeviz/data/shell-help/getting-started.md
@@ -1,0 +1,41 @@
+# Getting Started with 3viz
+
+3viz is a command-line tool for visualizing Abstract Syntax Trees (ASTs) in a readable, hierarchical format.
+
+## Quick Start
+
+**Basic Usage:**
+```bash
+# Visualize a JSON AST with default adapter
+3viz document.json
+
+# Use a specific adapter  
+3viz document.json mdast
+
+# Read from stdin
+cat document.json | 3viz - mdast
+
+# Output in different formats
+3viz document.json --output-format yaml
+```
+
+**Common Workflows:**
+
+1. **Exploring a new AST format**: Start with the default 3viz adapter to see the raw structure
+2. **Using built-in adapters**: Try mdast for Markdown or unist for generic trees  
+3. **Creating custom adapters**: Define field mappings for your specific AST format
+4. **Processing output**: Use JSON/YAML formats for further analysis
+
+## What You'll See
+
+3viz shows your AST as an indented tree with:
+- Visual icons for different node types
+- Content size indicators (line counts)
+- Hierarchical structure through indentation
+- Node labels and metadata
+
+## Next Steps
+
+- `3viz help adapters` - Learn about adapters and format mapping
+- `3viz help 3viz-output` - Understand output formats and structure
+- `3viz get-definition mdast` - See adapter definitions


### PR DESCRIPTION
## Summary
- Implement `3viz help <topic>` command with dynamic topic discovery
- Add help content for adapters, getting-started, examples, and output format
- Custom Click group that discovers markdown files and creates commands dynamically
- Proper fallback behavior for unknown topics
- Updated packaging configuration to include help files

## Test plan
- [x] Test help command discovery and loading
- [x] Test fallback to default help for unknown topics  
- [x] Test dynamic command creation from markdown files
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)